### PR TITLE
Raise an error if the c++ version is lower than 20.

### DIFF
--- a/cmake_modules/FindHedgehog.cmake
+++ b/cmake_modules/FindHedgehog.cmake
@@ -17,8 +17,11 @@
 #
 
 # Ensure C++20
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+if (CMAKE_CXX_STANDARD LESS 20)
+  message(FATAL_ERROR
+    "Hedgehog requires at least C++20 and the current version of C++ is set to '${CMAKE_CXX_STANDARD}'.\n"
+    "Consider setting CMAKE_CXX_STANDARD to 20 or higher.")
+endif()
 
 option(TEST_HEDGEHOG "Downloads google unit test API and runs google test scripts to test Hedgehog core and api" ON)
 option(HH_CX "Enable compile-time library for Hedgehog" OFF)


### PR DESCRIPTION
Changed the CMake package config to raise an error when the C++ standard is less than C++20 instead of changing the standard directly. The standard version shouldn't be changed in packages to ensure compatibility with future code.

Problem of changing the standard in the package:

```cmake
...
set(CMAKE_CXX_STANDARD 23)

find_package(Hedgehog REQUIRED)

# the standard is set back to 20 !!!
```