### PR TITLE
Lambda Task

### DIFF
--- a/hedgehog/hedgehog.h
+++ b/hedgehog/hedgehog.h
@@ -35,12 +35,14 @@
 #include "src/api/graph/graph.h"
 #include "src/api/graph/graph_signal_handler.h"
 #include "src/api/execution_pipeline/abstract_execution_pipeline.h"
+#include "src/api/task/lambda_task.h"
 
 #include "src/api/memory_manager/manager/memory_manager.h"
 #include "src/api/memory_manager/managed_memory.h"
 #include "src/api/memory_manager/manager/static_memory_manager.h"
 
 #include "src/api/state_manager/state_manager.h"
+
 
 #ifdef HH_USE_CUDA
 #include "src/api/task/abstract_cuda_task.h"

--- a/hedgehog/src/api/task/lambda_task.h
+++ b/hedgehog/src/api/task/lambda_task.h
@@ -1,0 +1,121 @@
+// NIST-developed software is provided by NIST as a public service. You may use, copy and distribute copies of the
+// software in any medium, provided that you keep intact this entire notice. You may improve, modify and create
+// derivative works of the software or any portion of the software, and you may copy and distribute such modifications
+// or works. Modified works should carry a notice stating that you changed the software and should note the date and
+// nature of any such change. Please explicitly acknowledge the National Institute of Standards and Technology as the
+// source of the software. NIST-developed software is expressly provided "AS IS." NIST MAKES NO WARRANTY OF ANY KIND,
+// EXPRESS, IMPLIED, IN FACT OR ARISING BY OPERATION OF LAW, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTY OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT AND DATA ACCURACY. NIST NEITHER REPRESENTS NOR
+// WARRANTS THAT THE OPERATION OF THE SOFTWARE WILL BE UNINTERRUPTED OR ERROR-FREE, OR THAT ANY DEFECTS WILL BE
+// CORRECTED. NIST DOES NOT WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE OF THE SOFTWARE OR THE RESULTS
+// THEREOF, INCLUDING BUT NOT LIMITED TO THE CORRECTNESS, ACCURACY, RELIABILITY, OR USEFULNESS OF THE SOFTWARE. You
+// are solely responsible for determining the appropriateness of using and distributing the software and you assume
+// all risks associated with its use, including but not limited to the risks and costs of program errors, compliance
+// with applicable laws, damage to or loss of data, programs or equipment, and the unavailability or interruption of
+// operation. This software is not intended to be used in any situation where a failure could cause risk of injury or
+// damage to property. The software developed by NIST employees is not subject to copyright protection within the
+// United States.
+
+#ifndef HEDGEHOG_LAMBDA_TASK_H
+#define HEDGEHOG_LAMBDA_TASK_H
+
+#include "../../core/implementors/concrete_implementor/task/internal_lambda_task.h"
+
+
+/// @brief Hedgehog main namespace
+namespace hh {
+
+/// @brief Type alias to the InternalLambdaTask
+template <class SubType, size_t Separator, class ...AllTypes>
+using ILT = core::implementor::InternalLambdaTask<SubType, Separator, AllTypes...>;
+
+/// @brief Specialized lambda task interface (for user-defined lambda task)
+/// @tparam SubType Type of the inheriting specialized lambda task (CRTP, void by default)
+/// @tparam Separator Separator position between input types and output types
+/// @tparam AllTypes List of input and output types
+template <class SubType, size_t Separator, class ...AllTypes>
+class SpecializedLambdaTask : 
+    public ILT<SubType, Separator, AllTypes...> {
+ public:
+  /// @brief Type alias to the lambda container type
+  using Lambdas = tool::LambdaContainerDeducer_t<SubType, tool::Inputs<Separator, AllTypes...>>;
+
+ public:
+  /// @brief Construct a lambda task with a pointer to the subclass, a tuple of lambda functions, a name, its number of 
+  ///        threads (default 1) and if the task should start automatically or not (default should not start automatically)
+  /// @param self Pointer to the user-defined lambda task (CRTP)
+  /// @param lambda Tuple of lambda functions (one function per input type of the task)
+  /// @param name Task name
+  /// @param numberThreads Task number of threads
+  /// @param automaticStart Flag to start the execution of the task without data (sending automatically nullptr to each
+  /// of the input types)
+  /// @throw std::runtime_error the number of threads == 0 or the core is not of the right type (do not derive from CoreTask)
+  explicit SpecializedLambdaTask(SubType *self, Lambdas lambdas, std::string const &name = "Task", size_t const numberThreads = 1,
+          bool const automaticStart = false)
+      : ILT<SubType, Separator, AllTypes...>(self, lambdas, name, numberThreads, automaticStart) {}
+
+  /// @brief Construct a lambda task with the pionter to the subclass, a name, its number of threads (default 1) and if
+  ///        the task should start automatically or not (default should not start automatically)
+  /// @param self Pointer to the user-defined lambda task (CRTP)
+  /// @param name Task name
+  /// @param numberThreads Task number of threads
+  /// @param automaticStart Flag to start the execution of the task without data (sending automatically nullptr to each
+  /// of the input types)
+  /// @throw std::runtime_error the number of threads == 0 or the core is not of the right type (do not derive from CoreTask)
+  explicit SpecializedLambdaTask(SubType *self, std::string const &name = "Task", size_t const numberThreads = 1,
+          bool const automaticStart = false)
+      : SpecializedLambdaTask<SubType, Separator, AllTypes...>(self, {}, name, numberThreads, automaticStart) {}
+
+  /// @brief A custom core can be used to customize how the task behaves internally. For example, by default any input
+  ///        is stored in a std::queue, it can be changed to a std::priority_queue instead through the core.
+  /// @param self Pointer to the lambda task
+  /// @param coreTask Custom core used to change the behavior of the task
+  explicit SpecializedLambdaTask(SubType *self, std::shared_ptr<core::implementor::LambdaCoreTask<SubType, Separator, AllTypes...>> coreTask) 
+      : ILT<SubType, Separator, AllTypes...>(self, coreTask) {}
+};
+
+/// @brief Default lambda task (there is no subtype so it shouldn't be specified)
+/// @tparam Separator Separator position between input types and output types
+/// @tparam AllTypes List of input and output types
+template <size_t Separator, class ...AllTypes>
+class LambdaTask
+    : public ILT<LambdaTask<Separator, AllTypes...>, Separator, AllTypes...> {
+ public:
+  /// @brief Type alias to the lambda container type
+  using Lambdas = tool::LambdaContainerDeducer_t<LambdaTask<Separator, AllTypes...>, tool::Inputs<Separator, AllTypes...>>;
+
+ public:
+  /// @brief Construct a lambda task with a tuple of lambda functions, a name, its number of threads (default 1) and if
+  ///        the task should start automatically or not (default should not start automatically)
+  /// @param lambda Tuple of lambda functions (one function per input type of the task)
+  /// @param name Task name
+  /// @param numberThreads Task number of threads
+  /// @param automaticStart Flag to start the execution of the task without data (sending automatically nullptr to each
+  /// of the input types)
+  /// @throw std::runtime_error the number of threads == 0 or the core is not of the right type (do not derive from CoreTask)
+  explicit LambdaTask(Lambdas lambdas, std::string const &name = "Task", size_t const numberThreads = 1,
+          bool const automaticStart = false)
+      : ILT<LambdaTask<Separator, AllTypes...>, Separator, AllTypes...>(this, lambdas, name, numberThreads, automaticStart) {}
+
+  /// @brief Construct a lambda task with a tuple of lambda functions, a name, its number of threads (default 1) and if
+  ///        the task should start automatically or not (default should not start automatically)
+  /// @param lambda Tuple of lambda functions (one function per input type of the task)
+  /// @param name Task name
+  /// @param numberThreads Task number of threads
+  /// @param automaticStart Flag to start the execution of the task without data (sending automatically nullptr to each
+  /// of the input types)
+  /// @throw std::runtime_error the number of threads == 0 or the core is not of the right type (do not derive from CoreTask)
+  explicit LambdaTask(std::string const &name = "Task", size_t const numberThreads = 1, bool const automaticStart = false)
+      : LambdaTask<Separator, AllTypes...>({}, name, numberThreads, automaticStart) {}
+
+  /// @brief A custom core can be used to customize how the task behaves internally. For example, by default any input
+  ///        is stored in a std::queue, it can be changed to a std::priority_queue instead through the core.
+  /// @param self Pointer to the lambda task
+  /// @param coreTask Custom core used to change the behavior of the task
+  explicit LambdaTask(std::shared_ptr<core::implementor::LambdaCoreTask<void, Separator, AllTypes...>> coreTask) 
+      : ILT<LambdaTask<Separator, AllTypes...>, Separator, AllTypes...>(this, coreTask) {}
+};
+
+}
+
+#endif //HEDGEHOG_LAMBDA_TASK_H

--- a/hedgehog/src/core/implementors/concrete_implementor/task/internal_lambda_task.h
+++ b/hedgehog/src/core/implementors/concrete_implementor/task/internal_lambda_task.h
@@ -1,0 +1,164 @@
+// NIST-developed software is provided by NIST as a public service. You may use, copy and distribute copies of the
+// software in any medium, provided that you keep intact this entire notice. You may improve, modify and create
+// derivative works of the software or any portion of the software, and you may copy and distribute such modifications
+// or works. Modified works should carry a notice stating that you changed the software and should note the date and
+// nature of any such change. Please explicitly acknowledge the National Institute of Standards and Technology as the
+// source of the software. NIST-developed software is expressly provided "AS IS." NIST MAKES NO WARRANTY OF ANY KIND,
+// EXPRESS, IMPLIED, IN FACT OR ARISING BY OPERATION OF LAW, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTY OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT AND DATA ACCURACY. NIST NEITHER REPRESENTS NOR
+// WARRANTS THAT THE OPERATION OF THE SOFTWARE WILL BE UNINTERRUPTED OR ERROR-FREE, OR THAT ANY DEFECTS WILL BE
+// CORRECTED. NIST DOES NOT WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE OF THE SOFTWARE OR THE RESULTS
+// THEREOF, INCLUDING BUT NOT LIMITED TO THE CORRECTNESS, ACCURACY, RELIABILITY, OR USEFULNESS OF THE SOFTWARE. You
+// are solely responsible for determining the appropriateness of using and distributing the software and you assume
+// all risks associated with its use, including but not limited to the risks and costs of program errors, compliance
+// with applicable laws, damage to or loss of data, programs or equipment, and the unavailability or interruption of
+// operation. This software is not intended to be used in any situation where a failure could cause risk of injury or
+// damage to property. The software developed by NIST employees is not subject to copyright protection within the
+// United States.
+
+#ifndef HEDGEHOG_INTERNAL_LAMBDA_TASK_H
+#define HEDGEHOG_INTERNAL_LAMBDA_TASK_H
+
+#include <memory>
+#include <string>
+#include <ostream>
+#include <utility>
+
+#include "../../../nodes/core_lambda_task.h"
+#include "../../../../behavior/task_node.h"
+#include "../../../../behavior/cleanable.h"
+#include "../../../../behavior/copyable.h"
+#include "../../../../behavior/can_terminate.h"
+#include "../../../../tools/traits.h"
+#include "lambda_multi_execute.h"
+#include "../../../nodes/core_lambda_task.h"
+
+/// @brief Hedgehog main namespace
+namespace hh {
+/// @brief Hedgehog core namespace
+namespace core {
+/// @brief Hedgehog implementor namespace
+namespace implementor {
+
+/// @brief Internal implementation of the lambda task
+/// @tparam SubType Type of the inheriting specialized lambda task (CRTP, void by default)
+/// @tparam Separator Separator position between input types and output types
+/// @tparam AllTypes List of input and output types
+template <typename SubType, size_t Separator, typename... AllTypes>
+class InternalLambdaTask
+    : public behavior::TaskNode,
+      public behavior::CanTerminate,
+      public behavior::Cleanable,
+      public behavior::Copyable<InternalLambdaTask<SubType, Separator, AllTypes...>>,
+      public tool::BehaviorMultiReceiversTypeDeducer_t<tool::Inputs<Separator, AllTypes...>>,
+      public LambdaMultiExecute<SubType, tool::Inputs<Separator, AllTypes...>>,
+      public tool::BehaviorTaskMultiSendersTypeDeducer_t<tool::Outputs<Separator, AllTypes...>> {
+ public:
+  /// @brief Type alias to the lambda container type
+  using Lambdas = tool::LambdaContainerDeducer_t<SubType, tool::Inputs<Separator, AllTypes...>>;
+
+ private:
+  std::shared_ptr<LambdaCoreTask<SubType, Separator, AllTypes...>> const
+      coreTask_ = nullptr; ///< Task core
+  Lambdas lambdas_ = {}; ///< Tuple of lambdas (one lambda function per input type)
+  SubType *self_ = nullptr; ///< Pointer to the user-defined task (CRTP)
+
+ public:
+  /// @brief TaskInterface is a friend of this class so it can expose the task interface
+  friend tool::TaskInterface<SubType>;
+
+ public:
+  /// @brief Construct a internal lambda task with a pointer to the subclass, the lambda functions, a name, its number
+  ///        of threads (default 1) and if the task should start automatically or not (default should not start automatically)
+  /// @param self Pointer to the user-defined LambdaTask
+  /// @param lambdas Lambda functions container
+  /// @param name Task name
+  /// @param numberThreads Task number of threads
+  /// @param automaticStart Flag to start the execution of the task without data (sending automatically nullptr to each
+  ///        of the input types)
+  /// @throw std::runtime_error the number of threads == 0 or the core is not of the right type (do not derive from CoreTask)
+  explicit InternalLambdaTask(SubType *self, Lambdas lambdas, std::string const &name, size_t const numberThreads,
+          bool const automaticStart)
+      : behavior::TaskNode(std::make_shared<LambdaCoreTask<SubType, Separator, AllTypes...>>(this,
+                                                                                             name,
+                                                                                             numberThreads,
+                                                                                             automaticStart)),
+        behavior::Copyable<InternalLambdaTask<SubType, Separator, AllTypes...>>(numberThreads),
+        LambdaMultiExecute<SubType, tool::Inputs<Separator, AllTypes...>>(lambdas, self),
+        tool::BehaviorTaskMultiSendersTypeDeducer_t<tool::Outputs<Separator, AllTypes...>>(
+            (std::dynamic_pointer_cast<LambdaCoreTask<SubType, Separator, AllTypes...>>(this->core()))),
+        coreTask_(std::dynamic_pointer_cast<LambdaCoreTask<SubType, Separator, AllTypes...>>(this->core())),
+        lambdas_(lambdas),
+        self_(self)
+  {
+    if (numberThreads == 0) { throw std::runtime_error("A task needs at least one thread."); }
+    if (coreTask_ == nullptr) { throw std::runtime_error("The core used by the task should be a CoreTask."); }
+  }
+
+  /// @brief A custom core can be used to customize how the task behaves internally. For example, by default any input
+  ///        is stored in a std::queue, it can be changed to a std::priority_queue instead through the core.
+  /// @param self Pointer to the lambda task
+  /// @param coreTask Custom core used to change the behavior of the task
+  explicit InternalLambdaTask(SubType *self, std::shared_ptr<LambdaCoreTask<SubType, Separator, AllTypes...>> coreTask)
+      : behavior::TaskNode(std::move(coreTask)),
+        behavior::Copyable<InternalLambdaTask<SubType, Separator, AllTypes...>>(
+            std::dynamic_pointer_cast<LambdaCoreTask<SubType, Separator, AllTypes...>>(this->core())->numberThreads()),
+        tool::BehaviorTaskMultiSendersTypeDeducer_t<tool::Outputs<Separator, AllTypes...>>(
+            std::dynamic_pointer_cast<LambdaCoreTask<SubType, Separator, AllTypes...>>(this->core())),
+        LambdaMultiExecute<SubType, tool::Inputs<Separator, AllTypes...>>({}, self),
+        coreTask_(std::dynamic_pointer_cast<LambdaCoreTask<SubType, Separator, AllTypes...>>(this->core())),
+        lambdas_({}),
+        self_(self)
+  {
+  }
+
+  /// @brief Default destructor
+  ~InternalLambdaTask() override = default;
+
+ public:
+  /// @brief Set a lambda function for an input type
+  /// @tparam Input Input type
+  /// @param lambda Lambda function
+  template<hh::tool::ContainsInTupleConcept<tool::Inputs<Separator, AllTypes...>> Input>
+  void setLambda(void(lambda)(std::shared_ptr<Input>, tool::TaskInterface<SubType>)) {
+      std::get<void(*)(std::shared_ptr<Input>, tool::TaskInterface<SubType>)>(lambdas_) = lambda;
+      LambdaMultiExecute<SubType, tool::Inputs<Separator, AllTypes...>>::reinitialize(lambdas_, self_);
+  }
+
+  /// @brief Belonging graph id accessor
+  /// @return  Belonging graph id
+  [[nodiscard]] size_t graphId() const { return coreTask_->graphId(); }
+
+  /// @brief Default termination rule, it terminates if there is no predecessor connection and there is no input data
+  /// @return True if the task can terminate, else false
+  [[nodiscard]] bool canTerminate() const override {
+    return !coreTask_->hasNotifierConnected() && coreTask_->receiversEmpty();
+  }
+
+  /// @brief Automatic start flag accessor
+  /// @return True if the task is set to automatically start, else false
+  [[nodiscard]] bool automaticStart() const { return this->coreTask()->automaticStart(); }
+
+  /// @brief Implementation of the copy trait
+  /// @return Copy of the lambda task
+  std::shared_ptr<InternalLambdaTask<SubType, Separator, AllTypes...>>
+  copy() override {
+    return std::make_shared<InternalLambdaTask<SubType, Separator, AllTypes...>>(
+        this->self_, this->lambdas_, this->name(), this->numberThreads(), this->automaticStart());
+  }
+
+ protected:
+  /// @brief Accessor to the core task
+  /// @return Core task
+  std::shared_ptr<LambdaCoreTask<SubType, Separator, AllTypes...>> const &coreTask() const { return coreTask_; }
+
+  /// @brief Accessor to device id linked to the task (default 0 for CPU task)
+  /// @return Device id linked to the task
+  [[nodiscard]] int deviceId() const { return coreTask_->deviceId(); }
+};
+
+}
+}
+}
+
+#endif //HEDGEHOG_INTERNAL_LAMBDA_TASK_H

--- a/hedgehog/src/core/implementors/concrete_implementor/task/lambda_execute.h
+++ b/hedgehog/src/core/implementors/concrete_implementor/task/lambda_execute.h
@@ -1,0 +1,73 @@
+// NIST-developed software is provided by NIST as a public service. You may use, copy and distribute copies of the
+// software in any medium, provided that you keep intact this entire notice. You may improve, modify and create
+// derivative works of the software or any portion of the software, and you may copy and distribute such modifications
+// or works. Modified works should carry a notice stating that you changed the software and should note the date and
+// nature of any such change. Please explicitly acknowledge the National Institute of Standards and Technology as the
+// source of the software. NIST-developed software is expressly provided "AS IS." NIST MAKES NO WARRANTY OF ANY KIND,
+// EXPRESS, IMPLIED, IN FACT OR ARISING BY OPERATION OF LAW, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTY OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT AND DATA ACCURACY. NIST NEITHER REPRESENTS NOR
+// WARRANTS THAT THE OPERATION OF THE SOFTWARE WILL BE UNINTERRUPTED OR ERROR-FREE, OR THAT ANY DEFECTS WILL BE
+// CORRECTED. NIST DOES NOT WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE OF THE SOFTWARE OR THE RESULTS
+// THEREOF, INCLUDING BUT NOT LIMITED TO THE CORRECTNESS, ACCURACY, RELIABILITY, OR USEFULNESS OF THE SOFTWARE. You
+// are solely responsible for determining the appropriateness of using and distributing the software and you assume
+// all risks associated with its use, including but not limited to the risks and costs of program errors, compliance
+// with applicable laws, damage to or loss of data, programs or equipment, and the unavailability or interruption of
+// operation. This software is not intended to be used in any situation where a failure could cause risk of injury or
+// damage to property. The software developed by NIST employees is not subject to copyright protection within the
+// United States.
+
+#ifndef HEDGEHOG_LAMBDA_EXECUTE_H
+#define HEDGEHOG_LAMBDA_EXECUTE_H
+#include <memory>
+#include "../../../../tools/task_interface.h"
+#include "../../../../tools/traits.h"
+
+
+/// @brief Hedgehog main namespace
+namespace hh {
+/// @brief Hedgehog core namespace
+namespace core {
+/// @brief Hedgehog implementor namespace
+namespace implementor {
+
+/// @brief Implementation of the Execute traits for the lambda task
+/// @tparam LambdaTaskType Type of the lambda task (CRTP)
+/// @tparam Input Type of the input.
+template <typename LambdaTaskType, typename Input>
+class LambdaExecute
+    : public tool::BehaviorMultiExecuteTypeDeducer_t<std::tuple<Input>>
+{
+ public:
+  /// @brief Type of the lambda function
+  using LambdaType = void(*)(std::shared_ptr<Input>, tool::TaskInterface<LambdaTaskType>);
+
+ private:
+  LambdaType lambda_; ///< Lambda function that should process the input type
+  tool::TaskInterface<LambdaTaskType> task_; ///< Interface to the inheriting task
+
+ public:
+  /// @brief Constructor with the lambda and the task
+  /// @param lambda Lambda function that will process the input type
+  /// @param task Pointer to the task (CRTP)
+  LambdaExecute(LambdaType lambda, LambdaTaskType *task) : lambda_(lambda), task_(task) { }
+
+  /// @brief Implementation of the execute function from the Execute trait
+  /// @param data Input data
+  void execute(std::shared_ptr<Input> data) override {
+      lambda_(data, task_);
+  }
+
+  /// @brief Reinitialize the members when the user call the `setLambda` function in the lambda task
+  /// @parma lambda New lambda function
+  /// @parma task New task
+  void reinitialize(LambdaType lambda, LambdaTaskType *task) {
+      lambda_ = lambda;
+      task_.task(task);
+  }
+};
+
+}
+}
+}
+
+#endif //HEDGEHOG_TASK_LAMBDA_EXECUTE_H

--- a/hedgehog/src/core/implementors/concrete_implementor/task/lambda_multi_execute.h
+++ b/hedgehog/src/core/implementors/concrete_implementor/task/lambda_multi_execute.h
@@ -1,0 +1,66 @@
+// NIST-developed software is provided by NIST as a public service. You may use, copy and distribute copies of the
+// software in any medium, provided that you keep intact this entire notice. You may improve, modify and create
+// derivative works of the software or any portion of the software, and you may copy and distribute such modifications
+// or works. Modified works should carry a notice stating that you changed the software and should note the date and
+// nature of any such change. Please explicitly acknowledge the National Institute of Standards and Technology as the
+// source of the software. NIST-developed software is expressly provided "AS IS." NIST MAKES NO WARRANTY OF ANY KIND,
+// EXPRESS, IMPLIED, IN FACT OR ARISING BY OPERATION OF LAW, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTY OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT AND DATA ACCURACY. NIST NEITHER REPRESENTS NOR
+// WARRANTS THAT THE OPERATION OF THE SOFTWARE WILL BE UNINTERRUPTED OR ERROR-FREE, OR THAT ANY DEFECTS WILL BE
+// CORRECTED. NIST DOES NOT WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE OF THE SOFTWARE OR THE RESULTS
+// THEREOF, INCLUDING BUT NOT LIMITED TO THE CORRECTNESS, ACCURACY, RELIABILITY, OR USEFULNESS OF THE SOFTWARE. You
+// are solely responsible for determining the appropriateness of using and distributing the software and you assume
+// all risks associated with its use, including but not limited to the risks and costs of program errors, compliance
+// with applicable laws, damage to or loss of data, programs or equipment, and the unavailability or interruption of
+// operation. This software is not intended to be used in any situation where a failure could cause risk of injury or
+// damage to property. The software developed by NIST employees is not subject to copyright protection within the
+// United States.
+
+#ifndef HEDGEHOG_LAMBDA_MULTI_EXECUTE_H
+#define HEDGEHOG_LAMBDA_MULTI_EXECUTE_H
+#include <tuple>
+#include "lambda_execute.h"
+
+
+/// @brief Hedgehog main namespace
+namespace hh {
+/// @brief Hedgehog core namespace
+namespace core {
+/// @brief Hedgehog implementor namespace
+namespace implementor {
+
+/// @brief Forward declaration of LambdaMultiExecute
+template<typename LambdaTaskType, typename Input>
+class LambdaMultiExecute;
+
+/// @brief Implemenation of the MultiExecute behavior for the lambda task
+/// @tparam LambdaTaskType Type of the lambda task (CRTP)
+/// @tparam Inputs Variadic of input types
+template<typename LambdaTaskType, typename ...Inputs>
+class LambdaMultiExecute<LambdaTaskType, std::tuple<Inputs...>>
+    : public LambdaExecute<LambdaTaskType, Inputs>... {
+  public:
+      /// @brief Type alias for the lambda container type
+      using LambdaContainer = std::tuple<void(*)(std::shared_ptr<Inputs>, tool::TaskInterface<LambdaTaskType>)...>;
+
+  public:
+      /// @brief Construct a LambdaMultiExecute with a tuple of lambdas and a pointer to the lambda task
+      /// @param lambdas Tuple of lambda functions
+      /// @param task Pointer to the lambda task
+      LambdaMultiExecute(LambdaContainer lambdas, LambdaTaskType *task)
+          : LambdaExecute<LambdaTaskType, Inputs>(
+                  std::get<void(*)(std::shared_ptr<Inputs>, tool::TaskInterface<LambdaTaskType>)>(lambdas), task)... {}
+
+      /// @breif Reinitialize the LambdaExecute (used when the user call `setLambda`)
+      /// @param lambdas Lambda container (new lambdas)
+      /// @parma task Pointer to the lambda task
+      void reinitialize(LambdaContainer lambdas, LambdaTaskType *task) {
+          (LambdaExecute<LambdaTaskType, Inputs>::reinitialize(std::get<void(*)(std::shared_ptr<Inputs>, tool::TaskInterface<LambdaTaskType>)>(lambdas), task), ...);
+      }
+};
+
+}
+}
+}
+
+#endif //HEDGEHOG_LAMBDA_MULTI_EXECUTE_H

--- a/hedgehog/src/core/nodes/core_lambda_task.h
+++ b/hedgehog/src/core/nodes/core_lambda_task.h
@@ -1,0 +1,351 @@
+// NIST-developed software is provided by NIST as a public service. You may use, copy and distribute copies of the
+// software in any medium, provided that you keep intact this entire notice. You may improve, modify and create
+// derivative works of the software or any portion of the software, and you may copy and distribute such modifications
+// or works. Modified works should carry a notice stating that you changed the software and should note the date and
+// nature of any such change. Please explicitly acknowledge the National Institute of Standards and Technology as the
+// source of the software. NIST-developed software is expressly provided "AS IS." NIST MAKES NO WARRANTY OF ANY KIND,
+// EXPRESS, IMPLIED, IN FACT OR ARISING BY OPERATION OF LAW, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTY OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT AND DATA ACCURACY. NIST NEITHER REPRESENTS NOR
+// WARRANTS THAT THE OPERATION OF THE SOFTWARE WILL BE UNINTERRUPTED OR ERROR-FREE, OR THAT ANY DEFECTS WILL BE
+// CORRECTED. NIST DOES NOT WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE OF THE SOFTWARE OR THE RESULTS
+// THEREOF, INCLUDING BUT NOT LIMITED TO THE CORRECTNESS, ACCURACY, RELIABILITY, OR USEFULNESS OF THE SOFTWARE. You
+// are solely responsible for determining the appropriateness of using and distributing the software and you assume
+// all risks associated with its use, including but not limited to the risks and costs of program errors, compliance
+// with applicable laws, damage to or loss of data, programs or equipment, and the unavailability or interruption of
+// operation. This software is not intended to be used in any situation where a failure could cause risk of injury or
+// damage to property. The software developed by NIST employees is not subject to copyright protection within the
+// United States.
+
+#ifndef HEDGEHOG_CORE_LAMBDA_TASK_H
+#define HEDGEHOG_CORE_LAMBDA_TASK_H
+#include <cstddef>
+#include <memory>
+#include <string>
+#include "../../tools/traits.h"
+#include "../abstractions/base/clonable_abstraction.h"
+#include "../abstractions/base/cleanable_abstraction.h"
+#include "../abstractions/base/groupable_abstraction.h"
+
+
+/// @brief Hedgehog main namespace
+namespace hh {
+/// @brief Hedgehog core namespace
+namespace core {
+/// @brief Hedgehog implementor namespace
+namespace implementor {
+
+
+/// @brief Forward definition to the internal implementation of the lambda task
+/// @tparam SubType Type of the inheriting specialized lambda task (CRTP, void by default)
+/// @tparam Separator Separator position between input types and output types
+/// @tparam AllTypes List of input and output types
+template <typename SubType, size_t Separator, typename... AllTypes>
+class InternalLambdaTask;
+
+/// @brief Type alias for an TaskInputsManagementAbstraction from the list of template parameters
+template<size_t Separator, class ...AllTypes>
+using TIM = tool::TaskInputsManagementAbstractionTypeDeducer_t<tool::Inputs<Separator, AllTypes...>>;
+
+/// @brief Type alias for an TaskOutputsManagementAbstraction from the list of template parameters
+template<size_t Separator, class ...AllTypes>
+using TOM = tool::TaskOutputsManagementAbstractionTypeDeducer_t<tool::Outputs<Separator, AllTypes...>>;
+
+/// @brief Lambda task core
+/// @tparam SubType Type of the specialized lambda task (CRTP, void by default)
+/// @tparam Separator Separator position between input types and output types
+/// @tparam AllTypes List of input and output types
+template<typename SubType, size_t Separator, class ...AllTypes>
+class LambdaCoreTask
+    : public abstraction::TaskNodeAbstraction,
+      public abstraction::ClonableAbstraction,
+      public abstraction::CleanableAbstraction,
+      public abstraction::GroupableAbstraction<InternalLambdaTask<SubType, Separator, AllTypes...>, LambdaCoreTask<SubType, Separator, AllTypes...>>,
+      public TIM<Separator, AllTypes...>,
+      public TOM<Separator, AllTypes...> {
+ private:
+  InternalLambdaTask<SubType, Separator, AllTypes...> *const 
+      task_ = nullptr; ///< User-defined task
+  bool const automaticStart_ = false; ///< Flag for automatic start
+
+ public:
+  /// @brief Create a LambdaCoreTask from a user-defined lambda task
+  /// @param task User-defined AbstractTask
+  explicit LambdaCoreTask(InternalLambdaTask<SubType, Separator, AllTypes...> *const task) :
+      TaskNodeAbstraction("Task", task),
+      CleanableAbstraction(static_cast<behavior::Cleanable *>(task)),
+      abstraction::GroupableAbstraction<InternalLambdaTask<SubType, Separator, AllTypes...>, LambdaCoreTask<SubType, Separator, AllTypes...>>(
+          task, 1
+      ),
+      TIM<Separator, AllTypes...>(task, this),
+      TOM<Separator, AllTypes...>(),
+      task_(task),
+      automaticStart_(false) {}
+
+  /// @brief Create a LambdaCoreTask from a user-defined LambdaTask, its  name, the number of threads and the automatic 
+  ///        start flag
+  /// @param task User-defined AbstractTask
+  /// @param name Task's name
+  /// @param numberThreads Number of threads
+  /// @param automaticStart Flag for automatic start
+  LambdaCoreTask(InternalLambdaTask<SubType, Separator, AllTypes...> *const task,
+           std::string const &name, size_t const numberThreads, bool const automaticStart) :
+      TaskNodeAbstraction(name, task),
+      CleanableAbstraction(static_cast<behavior::Cleanable *>(task)),
+      abstraction::GroupableAbstraction<InternalLambdaTask<SubType, Separator, AllTypes...>, LambdaCoreTask<SubType, Separator, AllTypes...>>(
+          task, numberThreads
+      ),
+      TIM<Separator, AllTypes...>(task, this),
+      TOM<Separator, AllTypes...>(),
+      task_(task),
+      automaticStart_(automaticStart) {
+    if (this->numberThreads() == 0) { throw std::runtime_error("A task needs at least one thread."); }
+  }
+
+  /// @brief Construct a task from the user-defined task and its concrete abstraction's implementations
+  /// @tparam ConcreteMultiReceivers Type of concrete implementation of ReceiverAbstraction for multiple types
+  /// @tparam ConcreteMultiExecutes Type of concrete implementation of ExecuteAbstraction for multiple types
+  /// @tparam ConcreteMultiSenders Type of concrete implementation of SenderAbstraction for multiple types
+  /// @param task User-defined task
+  /// @param name Task's name
+  /// @param numberThreads Number of threads for the task
+  /// @param automaticStart Flag for automatic start
+  /// @param concreteSlot Concrete implementation of SlotAbstraction
+  /// @param concreteMultiReceivers Concrete implementation of ReceiverAbstraction for multiple types
+  /// @param concreteMultiExecutes Concrete implementation of ExecuteAbstraction for multiple type
+  /// @param concreteNotifier Concrete implementation of NotifierAbstraction
+  /// @param concreteMultiSenders Concrete implementation of SenderAbstraction for multiple types
+  /// @throw std::runtime_error if the number of threads is 0
+  template<class ConcreteMultiReceivers, class ConcreteMultiExecutes, class ConcreteMultiSenders>
+  LambdaCoreTask(InternalLambdaTask<SubType, Separator, AllTypes...> *const task,
+           std::string const &name, size_t const numberThreads, bool const automaticStart,
+           std::shared_ptr<implementor::ImplementorSlot> concreteSlot,
+           std::shared_ptr<ConcreteMultiReceivers> concreteMultiReceivers,
+           std::shared_ptr<ConcreteMultiExecutes> concreteMultiExecutes,
+           std::shared_ptr<implementor::ImplementorNotifier> concreteNotifier,
+           std::shared_ptr<ConcreteMultiSenders> concreteMultiSenders) :
+      TaskNodeAbstraction(name, task),
+      CleanableAbstraction(static_cast<behavior::Cleanable *>(task)),
+      abstraction::GroupableAbstraction<InternalLambdaTask<SubType, Separator, AllTypes...>, LambdaCoreTask<SubType, Separator, AllTypes...>>
+          (task, numberThreads),
+      TIM<Separator, AllTypes...>(task, this, concreteSlot, concreteMultiReceivers, concreteMultiExecutes),
+      TOM<Separator, AllTypes...>(concreteNotifier, concreteMultiSenders),
+      task_(task),
+      automaticStart_(automaticStart) {
+    if (this->numberThreads() == 0) { throw std::runtime_error("A task needs at least one thread."); }
+  }
+
+  /// @brief Default destructor
+  ~LambdaCoreTask() override = default;
+
+  /// @brief Accessor to the memory manager
+  /// @return The attached memory manager
+  [[nodiscard]] std::shared_ptr<AbstractMemoryManager> memoryManager() const override {
+    return this->task_->memoryManager();
+  }
+
+  /// @brief Initialize the task
+  /// @details Call user define initialize, initialise memory manager if present
+  void preRun() override {
+    this->nvtxProfiler()->startRangeInitializing();
+    this->task_->initialize();
+    if (this->task_->memoryManager() != nullptr) {
+      this->task_->memoryManager()->profiler(this->nvtxProfiler());
+      this->task_->memoryManager()->deviceId(this->deviceId());
+      this->task_->memoryManager()->initialize();
+    }
+    this->nvtxProfiler()->endRangeInitializing();
+    this->setInitialized();
+  }
+
+  /// @brief Main core task logic
+  /// @details
+  /// - if automatic start
+  ///     - call user-defined task's execute method with nullptr
+  /// - while the task runs
+  ///     - wait for data or termination
+  ///     - if can terminate, break
+  ///     - get a piece of data from the queue
+  ///     - call user-defined state's execute method with data
+  /// - shutdown the task
+  /// - notify successors task terminated
+  void run() override {
+    std::chrono::time_point<std::chrono::system_clock>
+        start,
+        finish;
+
+    volatile bool canTerminate = false;
+
+    this->isActive(true);
+    this->nvtxProfiler()->initialize(this->threadId(), this->graphId());
+    this->preRun();
+
+    if (this->automaticStart_) {  this->callAllExecuteWithNullptr(); }
+
+    // Actual computation loop
+    while (!this->canTerminate()) {
+      // Wait for a data to arrive or termination
+      this->nvtxProfiler()->startRangeWaiting();
+      start = std::chrono::system_clock::now();
+      canTerminate = this->sleep();
+      finish = std::chrono::system_clock::now();
+      this->nvtxProfiler()->endRangeWaiting();
+      this->incrementWaitDuration(std::chrono::duration_cast<std::chrono::nanoseconds>(finish - start));
+
+      // If loop can terminate break the loop early
+      if (canTerminate) { break; }
+
+      // Operate the connectedReceivers to get a data and send it to execute
+      this->operateReceivers();
+    }
+
+    // Do the shutdown phase
+    this->postRun();
+    // Wake up a node that this node is linked to
+    this->wakeUp();
+  }
+
+  /// @brief When a task terminates, set the task to non active, call user-defined shutdown, and disconnect the task to
+  /// successor nodes
+  void postRun() override {
+    this->nvtxProfiler()->startRangeShuttingDown();
+    this->isActive(false);
+    this->task_->shutdown();
+    this->notifyAllTerminated();
+    this->nvtxProfiler()->endRangeShuttingDown();
+  }
+
+  /// @brief Create a group for this task, and connect each copies to the predecessor and successor nodes
+  /// @param map  Map of nodes and groups
+  /// @throw std::runtime_error it the task is ill-formed or the copy is not of the right type
+  void createGroup(std::map<NodeAbstraction *, std::vector<NodeAbstraction *>> &map) override {
+    abstraction::SlotAbstraction *coreCopyAsSlot;
+    abstraction::NotifierAbstraction *coreCopyAsNotifier;
+
+    for (size_t threadId = 1; threadId < this->numberThreads(); ++threadId) {
+      auto taskCopy = this->callCopyAndRegisterInGroup();
+
+      if (taskCopy == nullptr) {
+        std::ostringstream oss;
+        oss << "A copy for the task \"" << this->name()
+            << "\" has been invoked but return nullptr. To fix this error, overload the AbstractTask::copy function and "
+               "return a valid object.";
+        throw (std::runtime_error(oss.str()));
+      }
+
+      // Copy the memory manager
+      taskCopy->connectMemoryManager(this->task_->memoryManager());
+
+      auto taskCoreCopy = dynamic_cast<LambdaCoreTask<SubType, Separator, AllTypes...> *>(taskCopy->core().get());
+
+      if (taskCoreCopy == nullptr) {
+        std::ostringstream oss;
+        oss << "A copy for the task \"" << this->name()
+            << "\" does not have the same type of cores than the original task.";
+        throw (std::runtime_error(oss.str()));
+      }
+
+      // Deal with the group registration in the graph
+      map.at(static_cast<NodeAbstraction *>(this)).push_back(taskCoreCopy);
+
+      // Copy inner structures
+      taskCoreCopy->copyInnerStructure(this);
+
+      // Make necessary connections
+      coreCopyAsSlot = static_cast<abstraction::SlotAbstraction *>(taskCoreCopy);
+      coreCopyAsNotifier = static_cast<abstraction::NotifierAbstraction *>(taskCoreCopy);
+
+      for (auto predecessorNotifier : static_cast<abstraction::SlotAbstraction *>(this)->connectedNotifiers()) {
+        for (auto notifier : predecessorNotifier->notifiers()) {
+          for (auto slot : coreCopyAsSlot->slots()) {
+            slot->addNotifier(notifier);
+            notifier->addSlot(slot);
+          }
+        }
+      }
+
+      for (auto successorSlot : static_cast<abstraction::NotifierAbstraction *>(this)->connectedSlots()) {
+        for (auto slot : successorSlot->slots()) {
+          for (auto notifier : coreCopyAsNotifier->notifiers()) {
+            slot->addNotifier(notifier);
+            notifier->addSlot(slot);
+          }
+        }
+      }
+    }
+  }
+
+  /// @brief Test if a memory manager is attached
+  /// @return True if there is a memory manager attached, else false
+  [[nodiscard]] bool hasMemoryManagerAttached() const override { return this->memoryManager() != nullptr; }
+
+  /// @brief Accessor to the automatic start flag
+  /// @return true if the core start automatically, else false
+  [[nodiscard]] bool automaticStart() const { return automaticStart_; }
+
+  /// @brief Accessor to user-defined extra information for the task
+  /// @return User-defined extra information for the task
+  [[nodiscard]] std::string extraPrintingInformation() const override {
+    return this->task_->extraPrintingInformation();
+  }
+
+  /// @brief Copy task's inner structure
+  /// @param copyableCore Task to copy from
+  void copyInnerStructure(LambdaCoreTask<SubType, Separator, AllTypes...> *copyableCore) override {
+    TIM<Separator, AllTypes...>::copyInnerStructure(copyableCore);
+    TOM<Separator, AllTypes...>::copyInnerStructure(copyableCore);
+  }
+
+  /// @brief Node ids [nodeId, nodeGroupId] accessor
+  /// @return  Node ids [nodeId, nodeGroupId]
+  [[nodiscard]] std::vector<std::pair<std::string const, std::string const>> ids() const override {
+    return {{this->id(), this->groupRepresentativeId()}};
+  }
+  /// @brief Visit the task
+  /// @param printer Printer gathering task information
+  void visit(Printer *printer) override {
+    if (printer->registerNode(this)) {
+      printer->printNodeInformation(this);
+      TIM<Separator, AllTypes...>::printEdgesInformation(printer);
+    }
+  }
+
+  /// @brief Clone method, to duplicate a task when it is part of another graph in an execution pipeline
+  /// @param correspondenceMap Correspondence map of belonging graph's node
+  /// @return Clone of this task
+  std::shared_ptr<abstraction::NodeAbstraction> clone(
+      [[maybe_unused]] std::map<NodeAbstraction *, std::shared_ptr<NodeAbstraction>> &correspondenceMap) override {
+    auto clone = std::dynamic_pointer_cast<InternalLambdaTask<SubType, Separator, AllTypes...>>(this->callCopy());
+    if (this->hasMemoryManagerAttached()) { clone->connectMemoryManager(this->memoryManager()->copy()); }
+    return clone->core();
+  }
+
+  /// @brief Duplicate the task edge
+  /// @param mapping Correspondence map of belonging graph's node
+  void duplicateEdge(std::map<NodeAbstraction *, std::shared_ptr<NodeAbstraction>> &mapping) override {
+    this->duplicateOutputEdges(mapping);
+  }
+
+  /// @brief Accessor to the execution duration per input
+  /// @return A Map where the key is the type as string, and the value is the associated duration
+  [[nodiscard]] std::map<std::string, std::chrono::nanoseconds> const &executionDurationPerInput() const final {
+    return this->executionDurationPerInput_;
+  }
+
+  /// @brief Accessor to the number of elements per input
+  /// @return A Map where the key is the type as string, and the value is the associated number of elements received
+  [[nodiscard]] std::map<std::string, std::size_t> const &nbElementsPerInput() const final {
+    return this->nbElementsPerInput_;
+  }
+
+  /// @brief Accessor to the dequeue + execution duration per input
+  /// @return Map in which the key is the type and the value is the duration
+  [[nodiscard]] std::map<std::string, std::chrono::nanoseconds> const &dequeueExecutionDurationPerInput() const final {
+    return this->dequeueExecutionDurationPerInput_;
+  }
+};
+
+}
+}
+}
+
+#endif //HEDGEHOG_CORE_LAMBDA_TASK_H

--- a/hedgehog/src/tools/meta_functions.h
+++ b/hedgehog/src/tools/meta_functions.h
@@ -22,6 +22,8 @@
 #pragma once
 #include <iostream>
 #include <tuple>
+#include <memory>
+#include "task_interface.h"
 
 
 /// @brief Hedgehog main namespace
@@ -218,6 +220,31 @@ constexpr bool isContainedIn_v = std::disjunction_v<std::is_same<T, Ts>...>;
 /// @tparam Tuple Tuple of types
 template<class T, class Tuple>
 constexpr bool isContainedInTuple_v = std::tuple_size_v<Intersect_t<std::tuple<T>, Tuple>> == 1;
+
+/// @brief Lambda container type for the lambda task
+/// @tparam LambdaTaskType Type of the lambda task (CRTP)
+/// @tparam Inputs Input types of the lambda task
+template <class LambdaTaskType, class ...Inputs>
+using LambdaContainer = std::tuple<void(*)(std::shared_ptr<Inputs>, TaskInterface<LambdaTaskType>)...>;
+
+/// @brief Deduce the type of the lambda container in a lambda task
+/// @tparam LambdaTaskType Type of the lambda task (CRTP)
+/// @tparam Tuple Tuple of types
+template<class LambdaTaskType, class Tuple>
+struct LambdaContainerDeducer;
+
+/// @brief Deduce the type of the lambda container in a lambda task
+/// @tparam LambdaTaskType Type of the lambda task (CRTP)
+/// @tparam Inputs Input types of the lambda task
+template<class LambdaTaskType, class ...Inputs>
+struct LambdaContainerDeducer<LambdaTaskType, std::tuple<Inputs...>> { 
+    /// @brief Accessor to the type of the lambda container
+    using type = LambdaContainer<LambdaTaskType, Inputs...>; 
+};
+
+/// @brief Helper that gives the type of the lambda container in a lambda task
+template<class LambdaTaskType, class Tuple>
+using LambdaContainerDeducer_t = typename LambdaContainerDeducer<LambdaTaskType, Tuple>::type;
 
 /// @brief Create a string_view containing the type name
 /// @tparam T Type to create the string_view from

--- a/hedgehog/src/tools/task_interface.h
+++ b/hedgehog/src/tools/task_interface.h
@@ -1,0 +1,72 @@
+//  NIST-developed software is provided by NIST as a public service. You may use, copy and distribute copies of the
+//  software in any medium, provided that you keep intact this entire notice. You may improve, modify and create
+//  derivative works of the software or any portion of the software, and you may copy and distribute such modifications
+//  or works. Modified works should carry a notice stating that you changed the software and should note the date and
+//  nature of any such change. Please explicitly acknowledge the National Institute of Standards and Technology as the
+//  source of the software. NIST-developed software is expressly provided "AS IS." NIST MAKES NO WARRANTY OF ANY KIND,
+//  EXPRESS, IMPLIED, IN FACT OR ARISING BY OPERATION OF LAW, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTY OF
+//  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT AND DATA ACCURACY. NIST NEITHER REPRESENTS NOR
+//  WARRANTS THAT THE OPERATION OF THE SOFTWARE WILL BE UNINTERRUPTED OR ERROR-FREE, OR THAT ANY DEFECTS WILL BE
+//  CORRECTED. NIST DOES NOT WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE OF THE SOFTWARE OR THE RESULTS
+//  THEREOF, INCLUDING BUT NOT LIMITED TO THE CORRECTNESS, ACCURACY, RELIABILITY, OR USEFULNESS OF THE SOFTWARE. You
+//  are solely responsible for determining the appropriateness of using and distributing the software and you assume
+//  all risks associated with its use, including but not limited to the risks and costs of program errors, compliance
+//  with applicable laws, damage to or loss of data, programs or equipment, and the unavailability or interruption of
+//  operation. This software is not intended to be used in any situation where a failure could cause risk of injury or
+//  damage to property. The software developed by NIST employees is not subject to copyright protection within the
+//  United States.
+
+#ifndef HEDGEHOG_TASK_INTERFACE_H
+#define HEDGEHOG_TASK_INTERFACE_H
+#include "../api/memory_manager/managed_memory.h"
+#include <memory>
+
+
+/// @brief Hedgehog main namespace
+namespace hh {
+/// Hedgehog tool namespace
+namespace tool {
+
+/// @brief Class used to expose the Task interface in lambda functions of the lambda task
+/// @tparam TaskType Type of the lambda task.
+template <class TaskType>
+class TaskInterface {
+ private:
+  TaskType *task_ = nullptr; ///< lambda task (LambdaTask::this)
+
+ public:
+  /// @brief Constructor with input task
+  /// @param task Pointer to the task for which the interface is exposed
+  TaskInterface(TaskType *task) : task_(task) {}
+
+  /// @brief Default destructor
+  ~TaskInterface() = default;
+
+ public:
+  /// @brief Exposes LambdaTask::addResult
+  template <class T>
+  void addResult(std::shared_ptr<T> data) {
+      task_->addResult(data);
+  }
+
+  /// @brief Exposes LambdaTask::getManagedMemory
+  [[nodiscard]] std::shared_ptr<ManagedMemory> getManagedMemory() { return task_->getManagedMemory(); }
+
+  /// @brief Exposes LambdaTask::coreTask
+  [[nodiscard]] auto const &coreTask() const { return task_->coreTask_; }
+
+  /// @brief Exposes LambdaTask::deviceId
+  [[nodiscard]] int deviceId() const { return task_->coreTask_->deviceId(); }
+
+  /// @brief Operator that gives access to the methods of the specialized task
+  [[nodiscard]] TaskType *operator->() const { return task_; }
+
+  /// @brief Task setter
+  /// @param Pointer to the new task
+  void task(TaskType *task) { this->task_ = task; }
+};
+
+}
+}
+
+#endif //HEDGEHOG_TASK_INTERFACE_H

--- a/tests/data_structures/tasks/test_specialized_lambda_task.h
+++ b/tests/data_structures/tasks/test_specialized_lambda_task.h
@@ -1,0 +1,38 @@
+// NIST-developed software is provided by NIST as a public service. You may use, copy and distribute copies of the
+// software in any medium, provided that you keep intact this entire notice. You may improve, modify and create
+// derivative works of the software or any portion of the software, and you may copy and distribute such modifications
+// or works. Modified works should carry a notice stating that you changed the software and should note the date and
+// nature of any such change. Please explicitly acknowledge the National Institute of Standards and Technology as the
+// source of the software. NIST-developed software is expressly provided "AS IS." NIST MAKES NO WARRANTY OF ANY KIND,
+// EXPRESS, IMPLIED, IN FACT OR ARISING BY OPERATION OF LAW, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTY OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT AND DATA ACCURACY. NIST NEITHER REPRESENTS NOR
+// WARRANTS THAT THE OPERATION OF THE SOFTWARE WILL BE UNINTERRUPTED OR ERROR-FREE, OR THAT ANY DEFECTS WILL BE
+// CORRECTED. NIST DOES NOT WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE OF THE SOFTWARE OR THE RESULTS
+// THEREOF, INCLUDING BUT NOT LIMITED TO THE CORRECTNESS, ACCURACY, RELIABILITY, OR USEFULNESS OF THE SOFTWARE. You
+// are solely responsible for determining the appropriateness of using and distributing the software and you assume
+// all risks associated with its use, including but not limited to the risks and costs of program errors, compliance
+// with applicable laws, damage to or loss of data, programs or equipment, and the unavailability or interruption of
+// operation. This software is not intended to be used in any situation where a failure could cause risk of injury or
+// damage to property. The software developed by NIST employees is not subject to copyright protection within the
+// United States.
+
+#ifndef HEDGEHOG_TEST_SPECIALIZED_LAMBDA_TASK_H
+#define HEDGEHOG_TEST_SPECIALIZED_LAMBDA_TASK_H
+#include "../../../hedgehog/hedgehog.h"
+#include <memory>
+
+template <size_t Separator, typename ...AllTypes>
+class TestSpecializedLambdaTask 
+    : public hh::SpecializedLambdaTask<TestSpecializedLambdaTask<Separator, AllTypes...>, Separator, AllTypes...> {
+ private:
+  int number_ = 0;
+
+ public:
+  TestSpecializedLambdaTask(int number)
+      : hh::SpecializedLambdaTask<TestSpecializedLambdaTask, 1, int, int>(this),
+        number_(number) {}
+
+  [[nodiscard]] int number() const { return number_; }
+};
+
+#endif //HEDGEHOG_TEST_SPECIALIZED_LAMBDA_TASK_H

--- a/tests/test_hedgehog.cc
+++ b/tests/test_hedgehog.cc
@@ -22,6 +22,7 @@
 #include "tests_impl/test_complex_graph.h"
 #include "tests_impl/test_state_manager.h"
 #include "tests_impl/test_memory_manager.h"
+#include "tests_impl/test_lambda_task.h"
 
 #include "tests_impl/compile_time_tests/test_basic.h"
 #include "tests_impl/compile_time_tests/test_critical_path.h"
@@ -47,6 +48,11 @@ TEST(HedgehogGraph, complexGraph) {
   ASSERT_NO_THROW(testComplexEPComposition());
   ASSERT_NO_THROW(testCustomizedNodes());
   ASSERT_NO_THROW(testAtomicTask());
+}
+
+TEST(LambdaTask, lambdaTask) {
+  ASSERT_NO_THROW(lambdaTaskSingleInput());
+  ASSERT_NO_THROW(lambdaTaskMultipleInputs());
 }
 
 TEST(HedgehogTools, metafunctions) {

--- a/tests/test_hedgehog.cc
+++ b/tests/test_hedgehog.cc
@@ -53,6 +53,7 @@ TEST(HedgehogGraph, complexGraph) {
 TEST(LambdaTask, lambdaTask) {
   ASSERT_NO_THROW(lambdaTaskSingleInput());
   ASSERT_NO_THROW(lambdaTaskMultipleInputs());
+  ASSERT_NO_THROW(lambdaTaskSpecializedTask());
 }
 
 TEST(HedgehogTools, metafunctions) {

--- a/tests/tests_impl/test_lambda_task.h
+++ b/tests/tests_impl/test_lambda_task.h
@@ -19,7 +19,7 @@
 
 #include <gtest/gtest.h>
 #include <memory>
-#include "../data_structures/tasks/int_task.h"
+#include "../data_structures/tasks/test_specialized_lambda_task.h"
 
 void lambdaTaskSingleInput(){
   size_t count = 0;
@@ -39,7 +39,6 @@ void lambdaTaskSingleInput(){
   g.waitForTermination();
 
   EXPECT_EQ(count, 100);
-
 }
 
 void lambdaTaskMultipleInputs(){
@@ -75,3 +74,24 @@ void lambdaTaskMultipleInputs(){
   EXPECT_EQ(countDouble, 20);
 }
 
+void lambdaTaskSpecializedTask(){
+  size_t count = 0;
+  hh::Graph<1, int, int> g;
+  auto task = std::make_shared<TestSpecializedLambdaTask<1, int, int>>(4);
+  task->setLambda<int>([](std::shared_ptr<int> data, auto self) {
+      self.addResult(std::make_shared<int>(*data * self->number()));
+  });
+  g.inputs(task);
+  g.outputs(task);
+  g.executeGraph();
+  for(int i = 0; i < 4; ++i){ g.pushData(std::make_shared<int>(i)); }
+  g.finishPushingData();
+
+  while(auto res = g.getBlockingResult()){ 
+      count += *std::get<std::shared_ptr<int>>(*res); 
+  }
+
+  g.waitForTermination();
+
+  EXPECT_EQ(count, (0*4 + 1*4 + 2*4 + 3*4));
+}

--- a/tests/tests_impl/test_lambda_task.h
+++ b/tests/tests_impl/test_lambda_task.h
@@ -1,0 +1,77 @@
+// NIST-developed software is provided by NIST as a public service. You may use, copy and distribute copies of the
+// software in any medium, provided that you keep intact this entire notice. You may improve, modify and create
+// derivative works of the software or any portion of the software, and you may copy and distribute such modifications
+// or works. Modified works should carry a notice stating that you changed the software and should note the date and
+// nature of any such change. Please explicitly acknowledge the National Institute of Standards and Technology as the
+// source of the software. NIST-developed software is expressly provided "AS IS." NIST MAKES NO WARRANTY OF ANY KIND,
+// EXPRESS, IMPLIED, IN FACT OR ARISING BY OPERATION OF LAW, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTY OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT AND DATA ACCURACY. NIST NEITHER REPRESENTS NOR
+// WARRANTS THAT THE OPERATION OF THE SOFTWARE WILL BE UNINTERRUPTED OR ERROR-FREE, OR THAT ANY DEFECTS WILL BE
+// CORRECTED. NIST DOES NOT WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE OF THE SOFTWARE OR THE RESULTS
+// THEREOF, INCLUDING BUT NOT LIMITED TO THE CORRECTNESS, ACCURACY, RELIABILITY, OR USEFULNESS OF THE SOFTWARE. You
+// are solely responsible for determining the appropriateness of using and distributing the software and you assume
+// all risks associated with its use, including but not limited to the risks and costs of program errors, compliance
+// with applicable laws, damage to or loss of data, programs or equipment, and the unavailability or interruption of
+// operation. This software is not intended to be used in any situation where a failure could cause risk of injury or
+// damage to property. The software developed by NIST employees is not subject to copyright protection within the
+// United States.
+
+
+#include <gtest/gtest.h>
+#include <memory>
+#include "../data_structures/tasks/int_task.h"
+
+void lambdaTaskSingleInput(){
+  size_t count = 0;
+  hh::Graph<1, int, int> g;
+  auto intTask = std::make_shared<hh::LambdaTask<1, int, int>>();
+  intTask->setLambda<int>([](std::shared_ptr<int> data, auto self) {
+      self.addResult(data);
+  });
+  g.inputs(intTask);
+  g.outputs(intTask);
+  g.executeGraph();
+  for(int i = 0; i < 100; ++i){ g.pushData(std::make_shared<int>(i)); }
+  g.finishPushingData();
+
+  while(auto res = g.getBlockingResult()){ ++count; }
+
+  g.waitForTermination();
+
+  EXPECT_EQ(count, 100);
+
+}
+
+void lambdaTaskMultipleInputs(){
+  enum InputType { INT, DOUBLE };
+  int countInt = 0, countDouble = 0;
+  hh::Graph<2, int, double, InputType> g;
+  auto task = std::make_shared<hh::LambdaTask<2, int, double, InputType>>();
+
+  task->setLambda<int>([](std::shared_ptr<int>, auto self) {
+      self.addResult(std::make_shared<InputType>(INT));
+  });
+  task->setLambda<double>([](std::shared_ptr<double>, auto self) {
+      self.addResult(std::make_shared<InputType>(DOUBLE));
+  });
+
+  g.inputs(task);
+  g.outputs(task);
+  g.executeGraph();
+  for(int i = 0; i < 10; ++i){ g.pushData(std::make_shared<int>(i)); }
+  for(int i = 0; i < 20; ++i){ g.pushData(std::make_shared<double>(i)); }
+  g.finishPushingData();
+
+  while(auto res = g.getBlockingResult()){ 
+      switch (*std::get<std::shared_ptr<InputType>>(*res)) {
+      case INT: countInt++; break;
+      case DOUBLE: countDouble++; break;
+      }
+  }
+
+  g.waitForTermination();
+
+  EXPECT_EQ(countInt, 10);
+  EXPECT_EQ(countDouble, 20);
+}
+


### PR DESCRIPTION
Added the possibility to define task using lambda functions rather than defining a dedicated class.

Example:

```cpp
  auto task = std::make_shared<hh::LambdaTask<2, int, double, InputType>>();

  task->setLambda<int>([](std::shared_ptr<int>, auto self) {
      self.addResult(std::make_shared<InputType>(INT));
  });
  task->setLambda<double>([](std::shared_ptr<double>, auto self) {
      self.addResult(std::make_shared<InputType>(DOUBLE));
  });
```

Defining a specialized lambda task (I had to write a dedicated class for this, unfortunately, template specialization detects only the number of arguments and not the types):

```cpp
template <size_t Separator, typename ...AllTypes>
class TestSpecializedLambdaTask 
    : public hh::SpecializedLambdaTask<TestSpecializedLambdaTask<Separator, AllTypes...>, Separator, AllTypes...> {
 private:
  int number_ = 0;

 public:
  TestSpecializedLambdaTask(int number)
      : hh::SpecializedLambdaTask<TestSpecializedLambdaTask, 1, int, int>(this),
        number_(number) {}

  [[nodiscard]] int number() const { return number_; }
};
```

usable like this:

```cpp
  auto task = std::make_shared<TestSpecializedLambdaTask<1, int, int>>(4);

  task->setLambda<int>([](std::shared_ptr<int> data, auto self) {
      self.addResult(std::make_shared<int>(*data * self->number()));
  });
```

Possible issues with the current implementation:
- There is a bit of code duplication (I don't think it is too bad in this case)
- Naming and file organization