### PR TITLE
Using `std::function` instead of function pointers

### DIFF
--- a/hedgehog/src/core/implementors/concrete_implementor/task/internal_lambda_task.h
+++ b/hedgehog/src/core/implementors/concrete_implementor/task/internal_lambda_task.h
@@ -23,6 +23,7 @@
 #include <string>
 #include <ostream>
 #include <utility>
+#include <functional>
 
 #include "../../../nodes/core_lambda_task.h"
 #include "../../../../behavior/task_node.h"
@@ -120,8 +121,8 @@ class InternalLambdaTask
   /// @tparam Input Input type
   /// @param lambda Lambda function
   template<hh::tool::ContainsInTupleConcept<tool::Inputs<Separator, AllTypes...>> Input>
-  void setLambda(void(lambda)(std::shared_ptr<Input>, tool::TaskInterface<SubType>)) {
-      std::get<void(*)(std::shared_ptr<Input>, tool::TaskInterface<SubType>)>(lambdas_) = lambda;
+  void setLambda(std::function<void(std::shared_ptr<Input>, tool::TaskInterface<SubType>)> lambda) {
+      std::get<std::function<void(std::shared_ptr<Input>, tool::TaskInterface<SubType>)>>(lambdas_) = lambda;
       LambdaMultiExecute<SubType, tool::Inputs<Separator, AllTypes...>>::reinitialize(lambdas_, self_);
   }
 

--- a/hedgehog/src/core/implementors/concrete_implementor/task/lambda_execute.h
+++ b/hedgehog/src/core/implementors/concrete_implementor/task/lambda_execute.h
@@ -19,6 +19,7 @@
 #ifndef HEDGEHOG_LAMBDA_EXECUTE_H
 #define HEDGEHOG_LAMBDA_EXECUTE_H
 #include <memory>
+#include <functional>
 #include "../../../../tools/task_interface.h"
 #include "../../../../tools/traits.h"
 
@@ -39,7 +40,7 @@ class LambdaExecute
 {
  public:
   /// @brief Type of the lambda function
-  using LambdaType = void(*)(std::shared_ptr<Input>, tool::TaskInterface<LambdaTaskType>);
+  using LambdaType = std::function<void(std::shared_ptr<Input>, tool::TaskInterface<LambdaTaskType>)>;
 
  private:
   LambdaType lambda_; ///< Lambda function that should process the input type

--- a/hedgehog/src/core/implementors/concrete_implementor/task/lambda_multi_execute.h
+++ b/hedgehog/src/core/implementors/concrete_implementor/task/lambda_multi_execute.h
@@ -19,6 +19,7 @@
 #ifndef HEDGEHOG_LAMBDA_MULTI_EXECUTE_H
 #define HEDGEHOG_LAMBDA_MULTI_EXECUTE_H
 #include <tuple>
+#include <functional>
 #include "lambda_execute.h"
 
 
@@ -41,7 +42,7 @@ class LambdaMultiExecute<LambdaTaskType, std::tuple<Inputs...>>
     : public LambdaExecute<LambdaTaskType, Inputs>... {
   public:
       /// @brief Type alias for the lambda container type
-      using LambdaContainer = std::tuple<void(*)(std::shared_ptr<Inputs>, tool::TaskInterface<LambdaTaskType>)...>;
+      using LambdaContainer = std::tuple<std::function<void(std::shared_ptr<Inputs>, tool::TaskInterface<LambdaTaskType>)>...>;
 
   public:
       /// @brief Construct a LambdaMultiExecute with a tuple of lambdas and a pointer to the lambda task
@@ -49,13 +50,17 @@ class LambdaMultiExecute<LambdaTaskType, std::tuple<Inputs...>>
       /// @param task Pointer to the lambda task
       LambdaMultiExecute(LambdaContainer lambdas, LambdaTaskType *task)
           : LambdaExecute<LambdaTaskType, Inputs>(
-                  std::get<void(*)(std::shared_ptr<Inputs>, tool::TaskInterface<LambdaTaskType>)>(lambdas), task)... {}
+                  std::get<std::function<void(std::shared_ptr<Inputs>, tool::TaskInterface<LambdaTaskType>)>>(lambdas),
+                  task)... {}
 
       /// @breif Reinitialize the LambdaExecute (used when the user call `setLambda`)
       /// @param lambdas Lambda container (new lambdas)
       /// @parma task Pointer to the lambda task
       void reinitialize(LambdaContainer lambdas, LambdaTaskType *task) {
-          (LambdaExecute<LambdaTaskType, Inputs>::reinitialize(std::get<void(*)(std::shared_ptr<Inputs>, tool::TaskInterface<LambdaTaskType>)>(lambdas), task), ...);
+        (LambdaExecute<LambdaTaskType, Inputs>::reinitialize(
+             std::get<std::function<void(std::shared_ptr<Inputs>, tool::TaskInterface<LambdaTaskType>)>>(lambdas),
+             task),
+         ...);
       }
 };
 

--- a/hedgehog/src/tools/meta_functions.h
+++ b/hedgehog/src/tools/meta_functions.h
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <tuple>
 #include <memory>
+#include <functional>
 #include "task_interface.h"
 
 
@@ -225,7 +226,7 @@ constexpr bool isContainedInTuple_v = std::tuple_size_v<Intersect_t<std::tuple<T
 /// @tparam LambdaTaskType Type of the lambda task (CRTP)
 /// @tparam Inputs Input types of the lambda task
 template <class LambdaTaskType, class ...Inputs>
-using LambdaContainer = std::tuple<void(*)(std::shared_ptr<Inputs>, TaskInterface<LambdaTaskType>)...>;
+using LambdaContainer = std::tuple<std::function<void(std::shared_ptr<Inputs>, TaskInterface<LambdaTaskType>)>...>;
 
 /// @brief Deduce the type of the lambda container in a lambda task
 /// @tparam LambdaTaskType Type of the lambda task (CRTP)

--- a/tests/test_hedgehog.cc
+++ b/tests/test_hedgehog.cc
@@ -54,6 +54,7 @@ TEST(LambdaTask, lambdaTask) {
   ASSERT_NO_THROW(lambdaTaskSingleInput());
   ASSERT_NO_THROW(lambdaTaskMultipleInputs());
   ASSERT_NO_THROW(lambdaTaskSpecializedTask());
+  ASSERT_NO_THROW(lambdaTaskCaptureContext());
 }
 
 TEST(HedgehogTools, metafunctions) {

--- a/tests/tests_impl/test_lambda_task.h
+++ b/tests/tests_impl/test_lambda_task.h
@@ -95,3 +95,21 @@ void lambdaTaskSpecializedTask(){
 
   EXPECT_EQ(count, (0*4 + 1*4 + 2*4 + 3*4));
 }
+
+void lambdaTaskCaptureContext(){
+  size_t count = 0;
+  hh::Graph<1, int, int> g;
+  auto task = std::make_shared<hh::LambdaTask<1, int, int>>();
+  task->setLambda<int>([&count](std::shared_ptr<int> data, auto self) {
+      ++count;
+      self.addResult(data);
+  });
+  g.inputs(task);
+  g.outputs(task);
+  g.executeGraph();
+  for(int i = 0; i < 100; ++i){ g.pushData(std::make_shared<int>(i)); }
+  g.finishPushingData();
+  g.waitForTermination();
+
+  EXPECT_EQ(count, 100);
+}


### PR DESCRIPTION
Using `std::function` enables capturing variables in lambdas as well as using functors. The tradeoff is that `std::function` requires copies which will impact the creation of the graph (this not very important but still interesting to mention in case we want to make comparisons).