### PR TITLE
Make "_mm_pause()" intrinsic API call platform independent

### DIFF
--- a/hedgehog/src/core/implementors/concrete_implementor/default_sender.h
+++ b/hedgehog/src/core/implementors/concrete_implementor/default_sender.h
@@ -20,8 +20,7 @@
 #define HEDGEHOG_DEFAULT_SENDER_H
 
 #include <execution>
-#include <emmintrin.h>
-
+#include "../../../tools/intrinsics.h"
 #include "../implementor/implementor_sender.h"
 #include "../implementor/implementor_receiver.h"
 /// @brief Hedgehog main namespace
@@ -74,7 +73,7 @@ class DefaultSender : public ImplementorSender<Output> {
   void send(std::shared_ptr<Output> data) override {
     std::lock_guard<std::mutex> lck(mutex_);
     for (auto const &receiver : *receivers_) {
-      while(!receiver->receive(data)){ _mm_pause(); }
+      while(!receiver->receive(data)){ cross_platform_yield(); }
     }
   }
 };

--- a/hedgehog/src/core/implementors/concrete_implementor/graph/graph_receiver.h
+++ b/hedgehog/src/core/implementors/concrete_implementor/graph/graph_receiver.h
@@ -22,7 +22,7 @@
 #include <memory>
 #include <mutex>
 #include <execution>
-#include <emmintrin.h>
+// #include "../../../tools/intrinsics.h"
 
 #include "../../implementor/implementor_receiver.h"
 #include "../../../abstractions/base/input_output/receiver_abstraction.h"
@@ -103,7 +103,7 @@ class GraphReceiver : public ImplementorReceiver<Input> {
     std::for_each(
         this->abstractReceivers_->begin(), this->abstractReceivers_->end(),
         [&data](abstraction::ReceiverAbstraction<Input> *receiver) {
-          while(!receiver->receive(data)) { _mm_pause(); }
+          while(!receiver->receive(data)) { cross_platform_yield(); }
         }
     );
     return true;

--- a/hedgehog/src/core/implementors/concrete_implementor/receiver/atomic_queue_receiver.h
+++ b/hedgehog/src/core/implementors/concrete_implementor/receiver/atomic_queue_receiver.h
@@ -100,7 +100,7 @@ class AtomicQueueReceiver : public ImplementorReceiver<Input> {
   /// @brief Add a sender to the set of connected senders
   /// @param sender Sender to add to the connected senders
   void addSender(abstraction::SenderAbstraction<Input> *sender) override {
-    while (senderAccessFlag_.test_and_set(std::memory_order_acquire)) { _mm_pause(); }
+    while (senderAccessFlag_.test_and_set(std::memory_order_acquire)) { cross_platform_yield(); }
     senders_->insert(sender);
     senderAccessFlag_.clear(std::memory_order_release);
   }
@@ -108,7 +108,7 @@ class AtomicQueueReceiver : public ImplementorReceiver<Input> {
   /// @brief Remove a sender to the set of connected senders
   /// @param sender Sender to remove from the connected senders
   void removeSender(abstraction::SenderAbstraction<Input> *sender) override {
-    while (senderAccessFlag_.test_and_set(std::memory_order_acquire)) { _mm_pause(); }
+    while (senderAccessFlag_.test_and_set(std::memory_order_acquire)) { cross_platform_yield(); }
     senders_->erase(sender);
     senderAccessFlag_.clear(std::memory_order_release);
   }

--- a/hedgehog/src/core/implementors/concrete_implementor/slot/atomic_slot.h
+++ b/hedgehog/src/core/implementors/concrete_implementor/slot/atomic_slot.h
@@ -22,8 +22,7 @@
 #include <set>
 #include <atomic>
 #include <execution>
-#include <mmintrin.h>
-
+#include "../../../../tools/intrinsics.h"
 #include "../../implementor/implementor_slot.h"
 #include "../../implementor/implementor_notifier.h"
 #include "../../../../../constants.h"
@@ -50,7 +49,7 @@ class AtomicSlot : public ImplementorSlot {
   /// @brief Test if there is any notifiers connected
   /// @return True if there is any, else false
   [[nodiscard]] bool hasNotifierConnected() override {
-    while (notifierFlag_.exchange(true, std::memory_order_acquire)) { _mm_pause(); }
+    while (notifierFlag_.exchange(true, std::memory_order_acquire)) { cross_platform_yield(); }
     auto ret = !notifiers_->empty();
     notifierFlag_.store(false, std::memory_order_release);
     return ret;
@@ -59,7 +58,7 @@ class AtomicSlot : public ImplementorSlot {
   /// @brief Accessor to the number of notifiers connected
   /// @return Number of notifiers connected
   size_t nbNotifierConnected() override {
-    while (notifierFlag_.exchange(true, std::memory_order_acquire)) { _mm_pause(); }
+    while (notifierFlag_.exchange(true, std::memory_order_acquire)) { cross_platform_yield(); }
     auto ret = notifiers_->size();
     notifierFlag_.store(false, std::memory_order_release);
     return ret;
@@ -72,7 +71,7 @@ class AtomicSlot : public ImplementorSlot {
   /// @brief Add a notifier to the list of connected notifiers
   /// @param notifier Notifier to add to the list of connected notifiers
   void addNotifier(abstraction::NotifierAbstraction *notifier) override {
-    while (notifierFlag_.exchange(true, std::memory_order_acquire)) { _mm_pause(); }
+    while (notifierFlag_.exchange(true, std::memory_order_acquire)) { cross_platform_yield(); }
     notifiers_->insert(notifier);
     notifierFlag_.store(false, std::memory_order_release);
   }
@@ -80,7 +79,7 @@ class AtomicSlot : public ImplementorSlot {
   /// @brief Remove a notifier to the list of connected notifiers
   /// @param notifier Notifier to remove from the list of connected notifiers
   void removeNotifier(abstraction::NotifierAbstraction *notifier) override {
-    while (notifierFlag_.exchange(true, std::memory_order_acquire)) { _mm_pause(); }
+    while (notifierFlag_.exchange(true, std::memory_order_acquire)) { cross_platform_yield(); }
     notifiers_->erase(notifier);
     notifierFlag_.store(false, std::memory_order_release);
   }

--- a/hedgehog/src/core/nodes/core_execution_pipeline.h
+++ b/hedgehog/src/core/nodes/core_execution_pipeline.h
@@ -304,7 +304,7 @@ class CoreExecutionPipeline
       for (auto coreGraph : this->coreGraphs_) {
         if (EPIM<Separator, AllTypes...>::callSendToGraph(data, coreGraph->graphId())) {
           while(!std::static_pointer_cast<abstraction::ReceiverAbstraction<Input>>(coreGraph)->receive(data)) {
-            _mm_pause();
+            cross_platform_yield();
           }
           std::static_pointer_cast<abstraction::SlotAbstraction>(coreGraph)->wakeUp();
         }

--- a/hedgehog/src/tools/intrinsics.h
+++ b/hedgehog/src/tools/intrinsics.h
@@ -1,0 +1,31 @@
+//  NIST-developed software is provided by NIST as a public service. You may use, copy and distribute copies of the
+//  software in any medium, provided that you keep intact this entire notice. You may improve, modify and create
+//  derivative works of the software or any portion of the software, and you may copy and distribute such modifications
+//  or works. Modified works should carry a notice stating that you changed the software and should note the date and
+//  nature of any such change. Please explicitly acknowledge the National Institute of Standards and Technology as the
+//  source of the software. NIST-developed software is expressly provided "AS IS." NIST MAKES NO WARRANTY OF ANY KIND,
+//  EXPRESS, IMPLIED, IN FACT OR ARISING BY OPERATION OF LAW, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTY OF
+//  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT AND DATA ACCURACY. NIST NEITHER REPRESENTS NOR
+//  WARRANTS THAT THE OPERATION OF THE SOFTWARE WILL BE UNINTERRUPTED OR ERROR-FREE, OR THAT ANY DEFECTS WILL BE
+//  CORRECTED. NIST DOES NOT WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE OF THE SOFTWARE OR THE RESULTS
+//  THEREOF, INCLUDING BUT NOT LIMITED TO THE CORRECTNESS, ACCURACY, RELIABILITY, OR USEFULNESS OF THE SOFTWARE. You
+//  are solely responsible for determining the appropriateness of using and distributing the software and you assume
+//  all risks associated with its use, including but not limited to the risks and costs of program errors, compliance
+//  with applicable laws, damage to or loss of data, programs or equipment, and the unavailability or interruption of
+//  operation. This software is not intended to be used in any situation where a failure could cause risk of injury or
+//  damage to property. The software developed by NIST employees is not subject to copyright protection within the
+//  United States.
+
+#ifndef HEDGEHOG_INTRINSICS_H
+#define HEDGEHOG_INTRINSICS_H
+
+#pragma once
+
+#if defined(__x86_64__) || defined(_M_X64)
+    #include <emmintrin.h>
+    #define cross_platform_yield() _mm_pause()
+#else
+    #define cross_platform_yield() asm volatile("yield")
+#endif
+
+#endif //HEDGEHOG_INTRINSICS_H


### PR DESCRIPTION
- The `_mm_pause()` intrinsic API call is only supported on x86 architecture.
- This PR provides a macro `cross_platform_yield` which is defined depending on the platform architecture to add cross platform support.