### PR TITLE
Fixes cloning bug in hh::LambdaTask

### DIFF
--- a/hedgehog/src/api/task/lambda_task.h
+++ b/hedgehog/src/api/task/lambda_task.h
@@ -114,6 +114,13 @@ class LambdaTask
   /// @param coreTask Custom core used to change the behavior of the task
   explicit LambdaTask(std::shared_ptr<core::implementor::LambdaCoreTask<void, Separator, AllTypes...>> coreTask) 
       : ILT<LambdaTask<Separator, AllTypes...>, Separator, AllTypes...>(this, coreTask) {}
+
+  /// @brief Implementation of the copy trait
+  /// @return Copy of the lambda task
+  std::shared_ptr<ILT<LambdaTask, Separator, AllTypes...>>
+  copy() override {
+    return std::make_shared<LambdaTask>(this->lambdas(), this->name(), this->numberThreads(), this->automaticStart());
+  }
 };
 
 }

--- a/hedgehog/src/core/implementors/concrete_implementor/task/internal_lambda_task.h
+++ b/hedgehog/src/core/implementors/concrete_implementor/task/internal_lambda_task.h
@@ -144,14 +144,6 @@ class InternalLambdaTask
   /// @return True if the task is set to automatically start, else false
   [[nodiscard]] bool automaticStart() const { return this->coreTask()->automaticStart(); }
 
-  /// @brief Implementation of the copy trait
-  /// @return Copy of the lambda task
-  std::shared_ptr<InternalLambdaTask<SubType, Separator, AllTypes...>>
-  copy() override {
-    return std::make_shared<InternalLambdaTask<SubType, Separator, AllTypes...>>(
-        this->self_, this->lambdas(), this->name(), this->numberThreads(), this->automaticStart());
-  }
-
  protected:
   /// @brief Accessor to the core task
   /// @return Core task


### PR DESCRIPTION
- Solves the bug #12 by moving the copy functionality to derived class hh::LambdaTask from core::implementor::InternalLambdaTask