### PR TITLE
Batch queues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ find_package(TBB QUIET COMPONENTS tbb)
 find_package(Threads REQUIRED)
 find_package(CUDAToolkit QUIET)
 
+add_compile_options("-g")
+
 link_libraries(Threads::Threads)
 
 if (NOT CACHE_LINE_SIZE)
@@ -40,7 +42,7 @@ endif (HH_CX)
 
 if (CUDAToolkit_FOUND)
     message("CUDA found: ${CUDAToolkit_INCLUDE_DIRS}")
-    if (ENABLE_CHECK_CUDA) 
+    if (ENABLE_CHECK_CUDA)
         message("CUDA check enabled")
         add_definitions(-DHH_ENABLE_CHECK_CUDA)
     else (ENABLE_CHECK_CUDA)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,6 @@ find_package(TBB QUIET COMPONENTS tbb)
 find_package(Threads REQUIRED)
 find_package(CUDAToolkit QUIET)
 
-add_compile_options("-g")
-
 link_libraries(Threads::Threads)
 
 if (NOT CACHE_LINE_SIZE)

--- a/hedgehog/src/behavior/input_output/state_multi_senders.h
+++ b/hedgehog/src/behavior/input_output/state_multi_senders.h
@@ -44,6 +44,15 @@ class StateMultiSenders : public MultiSenders<Outputs...>, public StateSender<Ou
   template<tool::MatchOutputTypeConcept<Outputs...> DataType>
   void addResult(std::shared_ptr<DataType> data) { StateSender<DataType>::readyList()->push(data); }
 
+  /// @brief Add batc hresult to the ready list
+  /// @tparam DataType Type of the data, should be part of the state Output types
+  /// @param datas Datas of type DataType added to the ready list
+  template<tool::MatchOutputTypeConcept<Outputs...> DataType>
+  void batchAddResult(std::vector<std::shared_ptr<DataType>> const &datas) {
+    for (auto data : datas) {
+      StateSender<DataType>::readyList()->push(data);
+    }
+  }
 };
 }
 }

--- a/hedgehog/src/behavior/input_output/state_multi_senders.h
+++ b/hedgehog/src/behavior/input_output/state_multi_senders.h
@@ -31,6 +31,9 @@ namespace behavior {
 /// @tparam Outputs Types of data the state sends
 template<class ...Outputs>
 class StateMultiSenders : public MultiSenders<Outputs...>, public StateSender<Outputs>... {
+ private:
+  std::tuple<std::vector<std::shared_ptr<Outputs>>...> batchSendQueues_; ///< Vector for batch send (bufferResult/flushResults)
+
  public:
   /// @brief Default constructor
   StateMultiSenders() = default;
@@ -53,6 +56,23 @@ class StateMultiSenders : public MultiSenders<Outputs...>, public StateSender<Ou
       StateSender<DataType>::readyList()->push(data);
     }
   }
+
+  template<tool::MatchOutputTypeConcept<Outputs...> DataType>
+  void bufferResult(std::shared_ptr<DataType> data) {
+    std::get<std::vector<std::shared_ptr<DataType>>>(this->batchSendQueues_).emplace_back(data);
+  }
+
+
+  template<tool::MatchOutputTypeConcept<Outputs...> DataType>
+  void flushResults() {
+    auto &datas = std::get<std::vector<std::shared_ptr<DataType>>>(this->batchSendQueues_);
+    for (auto data : datas) {
+      StateSender<DataType>::readyList()->push(data);
+    }
+    datas.clear();
+  }
+
+  void flushResults() { (flushResults<Outputs>(), ...); }
 };
 }
 }

--- a/hedgehog/src/behavior/input_output/state_multi_senders.h
+++ b/hedgehog/src/behavior/input_output/state_multi_senders.h
@@ -47,7 +47,7 @@ class StateMultiSenders : public MultiSenders<Outputs...>, public StateSender<Ou
   template<tool::MatchOutputTypeConcept<Outputs...> DataType>
   void addResult(std::shared_ptr<DataType> data) { StateSender<DataType>::readyList()->push(data); }
 
-  /// @brief Add batc hresult to the ready list
+  /// @brief Add batch result to the ready list
   /// @tparam DataType Type of the data, should be part of the state Output types
   /// @param datas Datas of type DataType added to the ready list
   template<tool::MatchOutputTypeConcept<Outputs...> DataType>
@@ -57,12 +57,16 @@ class StateMultiSenders : public MultiSenders<Outputs...>, public StateSender<Ou
     }
   }
 
+  /// @brief Buffer a new result (do not send yet)
+  /// @tparam DataType Type of the data, should be part of the state Output types
+  /// @param data Data of type DataType that is buffered
   template<tool::MatchOutputTypeConcept<Outputs...> DataType>
   void bufferResult(std::shared_ptr<DataType> data) {
     std::get<std::vector<std::shared_ptr<DataType>>>(this->batchSendQueues_).emplace_back(data);
   }
 
-
+  /// @brief Send all the buffered data of a specific type.
+  /// @tparam DataType Type of the data that is sent, should be part of the state Output types
   template<tool::MatchOutputTypeConcept<Outputs...> DataType>
   void flushResults() {
     auto &datas = std::get<std::vector<std::shared_ptr<DataType>>>(this->batchSendQueues_);
@@ -72,6 +76,7 @@ class StateMultiSenders : public MultiSenders<Outputs...>, public StateSender<Ou
     datas.clear();
   }
 
+  // @brief Call `flushResults` for all the types.
   void flushResults() { (flushResults<Outputs>(), ...); }
 };
 }

--- a/hedgehog/src/behavior/input_output/task_multi_senders.h
+++ b/hedgehog/src/behavior/input_output/task_multi_senders.h
@@ -65,6 +65,15 @@ class TaskMultiSenders : public MultiSenders<Outputs...> {
       tom_->sendAndNotify(data);
     }
   }
+
+  template<tool::MatchOutputTypeConcept<Outputs...> DataType>
+  void batchAddResult(std::vector<std::shared_ptr<DataType>> const &data) {
+    if (tom_ == nullptr) {
+      throw std::runtime_error("A sender needs to have the abstraction initialized before used.");
+    } else {
+      tom_->batchSendAndNotify(data);
+    }
+  }
 };
 }
 }

--- a/hedgehog/src/behavior/input_output/task_multi_senders.h
+++ b/hedgehog/src/behavior/input_output/task_multi_senders.h
@@ -35,6 +35,8 @@ class TaskMultiSenders : public MultiSenders<Outputs...> {
   std::shared_ptr<core::abstraction::TaskOutputsManagementAbstraction<Outputs...>>
       tom_ = nullptr; ///< Link to the task's core TaskOutputsManagementAbstraction
 
+  std::tuple<std::vector<std::shared_ptr<Outputs>>...> batchSendQueues_; ///< Vector for batch send (bufferResult/flushResults)
+
  public:
   /// @brief Default constructor
   /// @tparam MultiSendersAndNotifier Type of core that has to implement TaskOutputsManagementAbstraction
@@ -71,13 +73,31 @@ class TaskMultiSenders : public MultiSenders<Outputs...> {
   /// @param data Vector of data of type DataType sent to the task successors
   /// @throw std::runtime_error The TaskOutputsManagementAbstraction abstraction is not initialized (== nullptr)
   template<tool::MatchOutputTypeConcept<Outputs...> DataType>
-  void batchAddResult(std::vector<std::shared_ptr<DataType>> const &data) {
+  void batchAddResult(std::vector<std::shared_ptr<DataType>> const &datas) {
     if (tom_ == nullptr) {
       throw std::runtime_error("A sender needs to have the abstraction initialized before used.");
     } else {
-      tom_->batchSendAndNotify(data);
+      tom_->batchSendAndNotify(datas);
     }
   }
+
+  template<tool::MatchOutputTypeConcept<Outputs...> DataType>
+  void bufferResult(std::shared_ptr<DataType> data) {
+    std::get<std::vector<std::shared_ptr<DataType>>>(this->batchSendQueues_).emplace_back(data);
+  }
+
+  template<tool::MatchOutputTypeConcept<Outputs...> DataType>
+  void flushResults() {
+    if (tom_ == nullptr) {
+      throw std::runtime_error("A sender needs to have the abstraction initialized before used.");
+    } else {
+      auto &datas = std::get<std::vector<std::shared_ptr<DataType>>>(this->batchSendQueues_);
+      tom_->batchSendAndNotify(datas);
+      datas.clear();
+    }
+  }
+
+  void flushResults() { (flushResults<Outputs>(), ...); }
 };
 }
 }

--- a/hedgehog/src/behavior/input_output/task_multi_senders.h
+++ b/hedgehog/src/behavior/input_output/task_multi_senders.h
@@ -35,7 +35,8 @@ class TaskMultiSenders : public MultiSenders<Outputs...> {
   std::shared_ptr<core::abstraction::TaskOutputsManagementAbstraction<Outputs...>>
       tom_ = nullptr; ///< Link to the task's core TaskOutputsManagementAbstraction
 
-  std::tuple<std::vector<std::shared_ptr<Outputs>>...> batchSendQueues_; ///< Vector for batch send (bufferResult/flushResults)
+  std::tuple<std::vector<std::shared_ptr<Outputs>>...>
+      batchSendQueues_ = {}; ///< Vector for batch send (bufferResult/flushResults)
 
  public:
   /// @brief Default constructor
@@ -81,11 +82,16 @@ class TaskMultiSenders : public MultiSenders<Outputs...> {
     }
   }
 
+  /// @brief Buffer a new result (not sent yet)
+  /// @tparam DataType Type of the data, should be part of the task Output types
+  /// @param data Vector of data of type DataType that will be sent to the task successors when `flushResult` is called.
   template<tool::MatchOutputTypeConcept<Outputs...> DataType>
   void bufferResult(std::shared_ptr<DataType> data) {
     std::get<std::vector<std::shared_ptr<DataType>>>(this->batchSendQueues_).emplace_back(data);
   }
 
+  /// @brief Send all the buffered result to the successors.
+  /// @tparam DataType Type to flush.
   template<tool::MatchOutputTypeConcept<Outputs...> DataType>
   void flushResults() {
     if (tom_ == nullptr) {
@@ -97,6 +103,7 @@ class TaskMultiSenders : public MultiSenders<Outputs...> {
     }
   }
 
+  // @brief Call `flushResults` for all the types.
   void flushResults() { (flushResults<Outputs>(), ...); }
 };
 }

--- a/hedgehog/src/behavior/input_output/task_multi_senders.h
+++ b/hedgehog/src/behavior/input_output/task_multi_senders.h
@@ -66,6 +66,10 @@ class TaskMultiSenders : public MultiSenders<Outputs...> {
     }
   }
 
+  /// @brief Add multiple results and send them to the task successors
+  /// @tparam DataType Type of the data, should be part of the task Output types
+  /// @param data Vector of data of type DataType sent to the task successors
+  /// @throw std::runtime_error The TaskOutputsManagementAbstraction abstraction is not initialized (== nullptr)
   template<tool::MatchOutputTypeConcept<Outputs...> DataType>
   void batchAddResult(std::vector<std::shared_ptr<DataType>> const &data) {
     if (tom_ == nullptr) {

--- a/hedgehog/src/core/abstractions/base/input_output/receiver_abstraction.h
+++ b/hedgehog/src/core/abstractions/base/input_output/receiver_abstraction.h
@@ -103,6 +103,8 @@ class ReceiverAbstraction {
   /// @return True if a data is available, else false
   bool getInputData(std::shared_ptr<Input> &data) { return concreteReceiver_->getInputData(data); }
 
+  bool getInputDatas(std::vector<std::shared_ptr<Input>> &datas, size_t count) { return concreteReceiver_->getInputDatas(datas, count); }
+
   /// @brief Accessor to the current number of input data received and waiting to be processed
   /// @return The current number of input data received and waiting to be processed
   [[nodiscard]] size_t numberElementsReceived() { return concreteReceiver_->numberElementsReceived(); }

--- a/hedgehog/src/core/abstractions/base/input_output/receiver_abstraction.h
+++ b/hedgehog/src/core/abstractions/base/input_output/receiver_abstraction.h
@@ -109,6 +109,10 @@ class ReceiverAbstraction {
   /// @return The current number of input data received and waiting to be processed
   [[nodiscard]] size_t numberElementsReceived() { return concreteReceiver_->numberElementsReceived(); }
 
+  /// @brief Returns the queue size after the last receive.
+  /// @return Queue size after the last receive.
+  [[nodiscard]] size_t queueSizeAfterLastReceive() { return concreteReceiver_->queueSizeAfterLastReceive(); }
+
   /// @brief Accessor to the maximum number of input data received and waiting to be processed
   /// @return The maximum number of input data received and waiting to be processed
   [[nodiscard]] size_t maxNumberElementsReceived() const { return concreteReceiver_->maxNumberElementsReceived();}

--- a/hedgehog/src/core/abstractions/base/input_output/receiver_abstraction.h
+++ b/hedgehog/src/core/abstractions/base/input_output/receiver_abstraction.h
@@ -103,8 +103,6 @@ class ReceiverAbstraction {
   /// @return True if a data is available, else false
   bool getInputData(std::shared_ptr<Input> &data) { return concreteReceiver_->getInputData(data); }
 
-  bool getInputDatas(std::vector<std::shared_ptr<Input>> &datas, size_t count) { return concreteReceiver_->getInputDatas(datas, count); }
-
   /// @brief Accessor to the current number of input data received and waiting to be processed
   /// @return The current number of input data received and waiting to be processed
   [[nodiscard]] size_t numberElementsReceived() { return concreteReceiver_->numberElementsReceived(); }

--- a/hedgehog/src/core/abstractions/base/input_output/receiver_abstraction.h
+++ b/hedgehog/src/core/abstractions/base/input_output/receiver_abstraction.h
@@ -95,6 +95,8 @@ class ReceiverAbstraction {
   /// @return True if the piece of data has been received, else false.
   bool receive(std::shared_ptr<Input> const inputData) { return concreteReceiver_->receive(inputData); }
 
+  bool batchReceive(std::vector<std::shared_ptr<Input>> const &inputDatas) { return concreteReceiver_->batchReceive(inputDatas); }
+
   /// @brief Get an input data from the concrete receiver implementation
   /// @details If a data is available, it is placed in data
   /// @param data Reference to the data to get from the receiver

--- a/hedgehog/src/core/abstractions/base/input_output/receiver_abstraction.h
+++ b/hedgehog/src/core/abstractions/base/input_output/receiver_abstraction.h
@@ -95,6 +95,10 @@ class ReceiverAbstraction {
   /// @return True if the piece of data has been received, else false.
   bool receive(std::shared_ptr<Input> const inputData) { return concreteReceiver_->receive(inputData); }
 
+  /// @brief Receive multiple pieces of data
+  /// @details Receive multiple pieces of data and transmit them to the concrete receiver implementation.
+  /// @param inputDatas Datas to transmit to the implementation
+  /// @return True if then data has been received, else false.
   bool batchReceive(std::vector<std::shared_ptr<Input>> const &inputDatas) { return concreteReceiver_->batchReceive(inputDatas); }
 
   /// @brief Get an input data from the concrete receiver implementation
@@ -106,10 +110,6 @@ class ReceiverAbstraction {
   /// @brief Accessor to the current number of input data received and waiting to be processed
   /// @return The current number of input data received and waiting to be processed
   [[nodiscard]] size_t numberElementsReceived() { return concreteReceiver_->numberElementsReceived(); }
-
-  /// @brief Returns the queue size after the last receive.
-  /// @return Queue size after the last receive.
-  [[nodiscard]] size_t queueSizeAfterLastReceive() { return concreteReceiver_->queueSizeAfterLastReceive(); }
 
   /// @brief Accessor to the maximum number of input data received and waiting to be processed
   /// @return The maximum number of input data received and waiting to be processed

--- a/hedgehog/src/core/abstractions/base/input_output/sender_abstraction.h
+++ b/hedgehog/src/core/abstractions/base/input_output/sender_abstraction.h
@@ -89,6 +89,8 @@ class SenderAbstraction {
   /// @param data Data to send to successor node or output of the graph
   void send(std::shared_ptr<Output> data) { concreteSender_->send(data); }
 
+  void batchSend(std::vector<std::shared_ptr<Output>> const &datas) { concreteSender_->batchSend(datas); }
+
  protected:
   /// @brief Copy inner structure of the sender to this one
   /// @param copyableCore SenderAbstraction to copy into this

--- a/hedgehog/src/core/abstractions/base/input_output/sender_abstraction.h
+++ b/hedgehog/src/core/abstractions/base/input_output/sender_abstraction.h
@@ -89,6 +89,8 @@ class SenderAbstraction {
   /// @param data Data to send to successor node or output of the graph
   void send(std::shared_ptr<Output> data) { concreteSender_->send(data); }
 
+  /// @brief Send datas as output of the node
+  /// @param datas Datas to send to successor node or output of the graph
   void batchSend(std::vector<std::shared_ptr<Output>> const &datas) { concreteSender_->batchSend(datas); }
 
  protected:

--- a/hedgehog/src/core/abstractions/node/task_inputs_management_abstraction.h
+++ b/hedgehog/src/core/abstractions/node/task_inputs_management_abstraction.h
@@ -159,8 +159,9 @@ class TaskInputsManagementAbstraction :
     size_t receiveCount = std::max(1UL, typedReceiver->numberElementsReceived() / numberThreads);
 
     [[likely]] if (typedReceiver->getInputDatas(datas, receiveCount)) {
-      // register the dequeue stats
-      incrementDequeueExecutionPerInput<InputDataType>(std::chrono::system_clock::now() - start);
+      finish = std::chrono::system_clock::now();
+      incrementDequeueExecutionPerInput<InputDataType>(finish - start);
+      coreTask_->incrementDequeueExecutionDuration(finish - start);
       for (auto data : datas) {
         coreTask_->incrementNumberReceivedElements();
         start = std::chrono::system_clock::now();

--- a/hedgehog/src/core/abstractions/node/task_inputs_management_abstraction.h
+++ b/hedgehog/src/core/abstractions/node/task_inputs_management_abstraction.h
@@ -55,8 +55,14 @@ class TaskInputsManagementAbstraction :
   std::map<std::string, std::chrono::nanoseconds>
       executionDurationPerInput_, ///< Node execution per input
   dequeueExecutionDurationPerInput_; ///< Node dequeue + execution per input
+                                     ///
+  std::map<std::string, size_t> nbElementsPerInput_; ///< Number of elements received per input
 
-  std::map<std::string, std::size_t> nbElementsPerInput_; ///< Number of elements received per input
+  struct QueueStats {
+      size_t minDequeueCount;
+      size_t maxDequeueCount;
+  };
+  std::map<std::string, QueueStats> dequeueStatsPerInput_; ///< Dequeue stats per input
 
  public:
   using inputs_t = std::tuple<Inputs...>; ///< Accessor to the input types
@@ -142,11 +148,18 @@ class TaskInputsManagementAbstraction :
     (ReceiverAbstraction<Inputs>::printEdgeInformation(printer), ...);
   }
 
+  std::string receiversExtraPrintingInformation() const {
+    std::ostringstream oss;
+    (oss << ... << this->receiverExtraPrintingInformation<Inputs>());
+    return oss.str();
+  }
+
  private:
   /// @brief Access the ReceiverAbstraction of the type InputDataType to process an element
   /// @tparam InputDataType Type of input data
   template<tool::ContainsConcept<Inputs...> InputDataType>
   void operateReceiver(size_t numberThreads) {
+    static std::string typeStr = hh::tool::typeToStr<InputDataType>();
     auto typedReceiver = static_cast<ReceiverAbstraction<InputDataType> *>(this);
     std::chrono::time_point<std::chrono::system_clock>
         start = std::chrono::system_clock::now(),
@@ -156,6 +169,10 @@ class TaskInputsManagementAbstraction :
     // TODO: this count may be wrong if the queue get's dequeued before numberElementsReceived is called
     size_t receiveCount = std::max(1UL, typedReceiver->numberElementsReceived() / numberThreads);
     [[likely]] if (typedReceiver->getInputDatas(datas, receiveCount)) {
+      this->dequeueStatsPerInput_[typeStr].minDequeueCount =
+          std::min(this->dequeueStatsPerInput_[typeStr].minDequeueCount, datas.size());
+      this->dequeueStatsPerInput_[typeStr].maxDequeueCount =
+          std::max(this->dequeueStatsPerInput_[typeStr].maxDequeueCount, datas.size());
       for (auto data : datas) {
         coreTask_->incrementNumberReceivedElements();
         callExecuteForAType(data);
@@ -201,6 +218,7 @@ class TaskInputsManagementAbstraction :
   void initializeMapsExecutionDurationPerInput() {
     static std::string typeStr = hh::tool::typeToStr<Input>();
     this->nbElementsPerInput_[typeStr] = {};
+    this->dequeueStatsPerInput_[typeStr] = {((size_t)-1), 0};
     this->executionDurationPerInput_[typeStr] = {};
     this->dequeueExecutionDurationPerInput_[typeStr] = {};
   }
@@ -222,6 +240,15 @@ class TaskInputsManagementAbstraction :
     this->dequeueExecutionDurationPerInput_.at(InputStr) += exec;
   }
 
+  template <class Input>
+  std::string receiverExtraPrintingInformation() const {
+    static std::string const typeStr = hh::tool::typeToStr<Input>();
+    std::ostringstream oss;
+    oss << typeStr << ": minDequeueCount = " << this->dequeueStatsPerInput_.at(typeStr).minDequeueCount
+        << ", maxDequeueCount = " << this->dequeueStatsPerInput_.at(typeStr).maxDequeueCount
+        << "\n";
+    return oss.str();
+  }
 };
 }
 }

--- a/hedgehog/src/core/abstractions/node/task_inputs_management_abstraction.h
+++ b/hedgehog/src/core/abstractions/node/task_inputs_management_abstraction.h
@@ -155,8 +155,8 @@ class TaskInputsManagementAbstraction :
         start = std::chrono::system_clock::now(),
         finish;
     auto &datas = std::get<std::vector<std::shared_ptr<InputDataType>>>(this->localQueues_);
-    // TODO: this count may be wrong if the queue get's dequeued before numberElementsReceived is called
-    size_t receiveCount = std::max(1UL, typedReceiver->numberElementsReceived() / numberThreads);
+    // NOTE: not sure if this receiveCount is always accurate
+    size_t receiveCount = std::max(1UL, typedReceiver->queueSizeAfterLastReceive() / numberThreads);
 
     [[likely]] if (typedReceiver->getInputDatas(datas, receiveCount)) {
       finish = std::chrono::system_clock::now();

--- a/hedgehog/src/core/abstractions/node/task_inputs_management_abstraction.h
+++ b/hedgehog/src/core/abstractions/node/task_inputs_management_abstraction.h
@@ -151,6 +151,10 @@ class TaskInputsManagementAbstraction :
   void operateReceiver(size_t numberThreads) {
     static std::string typeStr = hh::tool::typeToStr<InputDataType>();
     auto typedReceiver = static_cast<ReceiverAbstraction<InputDataType> *>(this);
+    if (typedReceiver->numberElementsReceived() == 0) {
+        // don't lock the queue if it's already empty
+        return;
+    }
     std::chrono::time_point<std::chrono::system_clock>
         start = std::chrono::system_clock::now(),
         finish;

--- a/hedgehog/src/core/abstractions/node/task_inputs_management_abstraction.h
+++ b/hedgehog/src/core/abstractions/node/task_inputs_management_abstraction.h
@@ -124,7 +124,7 @@ class TaskInputsManagementAbstraction :
   [[nodiscard]] bool canTerminate() override { return canTerminateNode_->canTerminate(); }
 
   /// @brief Access all the task receivers to process an element
-  void operateReceivers() { (this->operateReceiver<Inputs>(), ...); }
+  void operateReceivers(size_t numberThreads = 1) { (this->operateReceiver<Inputs>(numberThreads), ...); }
 
   /// @brief Call for all types the user-defined execute method with nullptr as data
   void callAllExecuteWithNullptr() { (callExecuteForATypeWithNullptr<Inputs>(), ...); }
@@ -146,18 +146,23 @@ class TaskInputsManagementAbstraction :
   /// @brief Access the ReceiverAbstraction of the type InputDataType to process an element
   /// @tparam InputDataType Type of input data
   template<tool::ContainsConcept<Inputs...> InputDataType>
-  void operateReceiver() {
+  void operateReceiver(size_t numberThreads) {
     auto typedReceiver = static_cast<ReceiverAbstraction<InputDataType> *>(this);
     std::chrono::time_point<std::chrono::system_clock>
         start = std::chrono::system_clock::now(),
         finish;
-    std::shared_ptr<InputDataType> data = nullptr;
-    [[likely]] if (typedReceiver->getInputData(data)) {
-      coreTask_->incrementNumberReceivedElements();
-      callExecuteForAType(data);
-      finish = std::chrono::system_clock::now();
-      incrementDequeueExecutionPerInput<InputDataType>(finish - start);
-      coreTask_->incrementDequeueExecutionDuration(finish - start);
+    // TODO: optimize this vector
+    std::vector<std::shared_ptr<InputDataType>> datas;
+    // TODO: this count may be wrong if the queue get's dequeued before numberElementsReceived is called
+    size_t receiveCount = std::max(1UL, typedReceiver->numberElementsReceived() / numberThreads);
+    [[likely]] if (typedReceiver->getInputDatas(datas, receiveCount)) {
+      for (auto data : datas) {
+        coreTask_->incrementNumberReceivedElements();
+        callExecuteForAType(data);
+        finish = std::chrono::system_clock::now();
+        incrementDequeueExecutionPerInput<InputDataType>(finish - start);
+        coreTask_->incrementDequeueExecutionDuration(finish - start);
+      }
     }
   }
 

--- a/hedgehog/src/core/abstractions/node/task_inputs_management_abstraction.h
+++ b/hedgehog/src/core/abstractions/node/task_inputs_management_abstraction.h
@@ -60,12 +60,6 @@ class TaskInputsManagementAbstraction :
                                      ///
   std::map<std::string, size_t> nbElementsPerInput_; ///< Number of elements received per input
 
-  struct QueueStats {
-      size_t minDequeueCount;
-      size_t maxDequeueCount;
-  };
-  std::map<std::string, QueueStats> dequeueStatsPerInput_; ///< Dequeue stats per input
-
  public:
   using inputs_t = std::tuple<Inputs...>; ///< Accessor to the input types
 
@@ -150,12 +144,6 @@ class TaskInputsManagementAbstraction :
     (ReceiverAbstraction<Inputs>::printEdgeInformation(printer), ...);
   }
 
-  std::string receiversExtraPrintingInformation() const {
-    std::ostringstream oss;
-    (oss << ... << this->receiverExtraPrintingInformation<Inputs>());
-    return oss.str();
-  }
-
  private:
   /// @brief Access the ReceiverAbstraction of the type InputDataType to process an element
   /// @tparam InputDataType Type of input data
@@ -173,10 +161,6 @@ class TaskInputsManagementAbstraction :
     [[likely]] if (typedReceiver->getInputDatas(datas, receiveCount)) {
       // register the dequeue stats
       incrementDequeueExecutionPerInput<InputDataType>(std::chrono::system_clock::now() - start);
-      this->dequeueStatsPerInput_[typeStr].minDequeueCount =
-          std::min(this->dequeueStatsPerInput_[typeStr].minDequeueCount, datas.size());
-      this->dequeueStatsPerInput_[typeStr].maxDequeueCount =
-          std::max(this->dequeueStatsPerInput_[typeStr].maxDequeueCount, datas.size());
       for (auto data : datas) {
         coreTask_->incrementNumberReceivedElements();
         start = std::chrono::system_clock::now();
@@ -224,7 +208,6 @@ class TaskInputsManagementAbstraction :
   void initializeMapsExecutionDurationPerInput() {
     static std::string typeStr = hh::tool::typeToStr<Input>();
     this->nbElementsPerInput_[typeStr] = {};
-    this->dequeueStatsPerInput_[typeStr] = {((size_t)-1), 0};
     this->executionDurationPerInput_[typeStr] = {};
     this->dequeueExecutionDurationPerInput_[typeStr] = {};
   }
@@ -244,16 +227,6 @@ class TaskInputsManagementAbstraction :
   void incrementDequeueExecutionPerInput(std::chrono::nanoseconds const &exec) {
     static std::string const InputStr = hh::tool::typeToStr<Input>();
     this->dequeueExecutionDurationPerInput_.at(InputStr) += exec;
-  }
-
-  template <class Input>
-  std::string receiverExtraPrintingInformation() const {
-    static std::string const typeStr = hh::tool::typeToStr<Input>();
-    std::ostringstream oss;
-    oss << typeStr << ": minDequeueCount = " << this->dequeueStatsPerInput_.at(typeStr).minDequeueCount
-        << ", maxDequeueCount = " << this->dequeueStatsPerInput_.at(typeStr).maxDequeueCount
-        << "\n";
-    return oss.str();
   }
 };
 }

--- a/hedgehog/src/core/abstractions/node/task_inputs_management_abstraction.h
+++ b/hedgehog/src/core/abstractions/node/task_inputs_management_abstraction.h
@@ -57,7 +57,7 @@ class TaskInputsManagementAbstraction :
   std::map<std::string, std::chrono::nanoseconds>
       executionDurationPerInput_, ///< Node execution per input
   dequeueExecutionDurationPerInput_; ///< Node dequeue + execution per input
-                                     ///
+
   std::map<std::string, size_t> nbElementsPerInput_; ///< Number of elements received per input
 
  public:

--- a/hedgehog/src/core/abstractions/node/task_inputs_management_abstraction.h
+++ b/hedgehog/src/core/abstractions/node/task_inputs_management_abstraction.h
@@ -51,6 +51,8 @@ class TaskInputsManagementAbstraction :
   TaskNodeAbstraction *const coreTask_ = nullptr; ///< Accessor to the core task
   hh::behavior::CanTerminate *const canTerminateNode_ = nullptr; ///< Accessor to the can terminate abstraction
 
+  std::tuple<std::vector<std::shared_ptr<Inputs>>...> localQueues_;
+
  protected:
   std::map<std::string, std::chrono::nanoseconds>
       executionDurationPerInput_, ///< Node execution per input
@@ -164,8 +166,7 @@ class TaskInputsManagementAbstraction :
     std::chrono::time_point<std::chrono::system_clock>
         start = std::chrono::system_clock::now(),
         finish;
-    // TODO: optimize this vector
-    std::vector<std::shared_ptr<InputDataType>> datas;
+    auto &datas = std::get<std::vector<std::shared_ptr<InputDataType>>>(this->localQueues_);
     // TODO: this count may be wrong if the queue get's dequeued before numberElementsReceived is called
     size_t receiveCount = std::max(1UL, typedReceiver->numberElementsReceived() / numberThreads);
     [[likely]] if (typedReceiver->getInputDatas(datas, receiveCount)) {
@@ -180,6 +181,7 @@ class TaskInputsManagementAbstraction :
         incrementDequeueExecutionPerInput<InputDataType>(finish - start);
         coreTask_->incrementDequeueExecutionDuration(finish - start);
       }
+      datas.clear();
     }
   }
 

--- a/hedgehog/src/core/abstractions/node/task_inputs_management_abstraction.h
+++ b/hedgehog/src/core/abstractions/node/task_inputs_management_abstraction.h
@@ -148,7 +148,7 @@ class TaskInputsManagementAbstraction :
   /// @brief Access the ReceiverAbstraction of the type InputDataType to process an element
   /// @tparam InputDataType Type of input data
   template<tool::ContainsConcept<Inputs...> InputDataType>
-  void operateReceiver(size_t numberThreads) {
+  void operateReceiver([[maybe_unused]]size_t numberThreads) {
     static std::string typeStr = hh::tool::typeToStr<InputDataType>();
     auto typedReceiver = static_cast<ReceiverAbstraction<InputDataType> *>(this);
     if (typedReceiver->numberElementsReceived() == 0) {
@@ -158,23 +158,18 @@ class TaskInputsManagementAbstraction :
     std::chrono::time_point<std::chrono::system_clock>
         start = std::chrono::system_clock::now(),
         finish;
-    auto &datas = std::get<std::vector<std::shared_ptr<InputDataType>>>(this->localQueues_);
-    // NOTE: not sure if this receiveCount is always accurate
-    size_t receiveCount = std::max(1UL, typedReceiver->queueSizeAfterLastReceive() / numberThreads);
+    std::shared_ptr<InputDataType> data = nullptr;
 
-    [[likely]] if (typedReceiver->getInputDatas(datas, receiveCount)) {
+    [[likely]] if (typedReceiver->getInputData(data)) {
       finish = std::chrono::system_clock::now();
       incrementDequeueExecutionPerInput<InputDataType>(finish - start);
       coreTask_->incrementDequeueExecutionDuration(finish - start);
-      for (auto data : datas) {
-        coreTask_->incrementNumberReceivedElements();
-        start = std::chrono::system_clock::now();
-        callExecuteForAType(data);
-        finish = std::chrono::system_clock::now();
-        incrementDequeueExecutionPerInput<InputDataType>(finish - start);
-        coreTask_->incrementDequeueExecutionDuration(finish - start);
-      }
-      datas.clear();
+      coreTask_->incrementNumberReceivedElements();
+      start = std::chrono::system_clock::now();
+      callExecuteForAType(data);
+      finish = std::chrono::system_clock::now();
+      incrementDequeueExecutionPerInput<InputDataType>(finish - start);
+      coreTask_->incrementDequeueExecutionDuration(finish - start);
     }
   }
 

--- a/hedgehog/src/core/abstractions/node/task_inputs_management_abstraction.h
+++ b/hedgehog/src/core/abstractions/node/task_inputs_management_abstraction.h
@@ -169,13 +169,17 @@ class TaskInputsManagementAbstraction :
     auto &datas = std::get<std::vector<std::shared_ptr<InputDataType>>>(this->localQueues_);
     // TODO: this count may be wrong if the queue get's dequeued before numberElementsReceived is called
     size_t receiveCount = std::max(1UL, typedReceiver->numberElementsReceived() / numberThreads);
+
     [[likely]] if (typedReceiver->getInputDatas(datas, receiveCount)) {
+      // register the dequeue stats
+      incrementDequeueExecutionPerInput<InputDataType>(std::chrono::system_clock::now() - start);
       this->dequeueStatsPerInput_[typeStr].minDequeueCount =
           std::min(this->dequeueStatsPerInput_[typeStr].minDequeueCount, datas.size());
       this->dequeueStatsPerInput_[typeStr].maxDequeueCount =
           std::max(this->dequeueStatsPerInput_[typeStr].maxDequeueCount, datas.size());
       for (auto data : datas) {
         coreTask_->incrementNumberReceivedElements();
+        start = std::chrono::system_clock::now();
         callExecuteForAType(data);
         finish = std::chrono::system_clock::now();
         incrementDequeueExecutionPerInput<InputDataType>(finish - start);

--- a/hedgehog/src/core/abstractions/node/task_inputs_management_abstraction.h
+++ b/hedgehog/src/core/abstractions/node/task_inputs_management_abstraction.h
@@ -51,14 +51,12 @@ class TaskInputsManagementAbstraction :
   TaskNodeAbstraction *const coreTask_ = nullptr; ///< Accessor to the core task
   hh::behavior::CanTerminate *const canTerminateNode_ = nullptr; ///< Accessor to the can terminate abstraction
 
-  std::tuple<std::vector<std::shared_ptr<Inputs>>...> localQueues_;
-
  protected:
   std::map<std::string, std::chrono::nanoseconds>
       executionDurationPerInput_, ///< Node execution per input
   dequeueExecutionDurationPerInput_; ///< Node dequeue + execution per input
 
-  std::map<std::string, size_t> nbElementsPerInput_; ///< Number of elements received per input
+  std::map<std::string, std::size_t> nbElementsPerInput_; ///< Number of elements received per input
 
  public:
   using inputs_t = std::tuple<Inputs...>; ///< Accessor to the input types
@@ -126,7 +124,7 @@ class TaskInputsManagementAbstraction :
   [[nodiscard]] bool canTerminate() override { return canTerminateNode_->canTerminate(); }
 
   /// @brief Access all the task receivers to process an element
-  void operateReceivers(size_t numberThreads = 1) { (this->operateReceiver<Inputs>(numberThreads), ...); }
+  void operateReceivers() { (this->operateReceiver<Inputs>(), ...); }
 
   /// @brief Call for all types the user-defined execute method with nullptr as data
   void callAllExecuteWithNullptr() { (callExecuteForATypeWithNullptr<Inputs>(), ...); }
@@ -148,11 +146,11 @@ class TaskInputsManagementAbstraction :
   /// @brief Access the ReceiverAbstraction of the type InputDataType to process an element
   /// @tparam InputDataType Type of input data
   template<tool::ContainsConcept<Inputs...> InputDataType>
-  void operateReceiver([[maybe_unused]]size_t numberThreads) {
-    static std::string typeStr = hh::tool::typeToStr<InputDataType>();
+  void operateReceiver() {
     auto typedReceiver = static_cast<ReceiverAbstraction<InputDataType> *>(this);
     if (typedReceiver->numberElementsReceived() == 0) {
-        // don't lock the queue if it's already empty
+        // don't lock the queue if it's already empty, if an element is pushed
+        // afterward, the node will be notify another time and retry to dequeue
         return;
     }
     std::chrono::time_point<std::chrono::system_clock>
@@ -161,11 +159,7 @@ class TaskInputsManagementAbstraction :
     std::shared_ptr<InputDataType> data = nullptr;
 
     [[likely]] if (typedReceiver->getInputData(data)) {
-      finish = std::chrono::system_clock::now();
-      incrementDequeueExecutionPerInput<InputDataType>(finish - start);
-      coreTask_->incrementDequeueExecutionDuration(finish - start);
       coreTask_->incrementNumberReceivedElements();
-      start = std::chrono::system_clock::now();
       callExecuteForAType(data);
       finish = std::chrono::system_clock::now();
       incrementDequeueExecutionPerInput<InputDataType>(finish - start);
@@ -228,6 +222,7 @@ class TaskInputsManagementAbstraction :
     static std::string const InputStr = hh::tool::typeToStr<Input>();
     this->dequeueExecutionDurationPerInput_.at(InputStr) += exec;
   }
+
 };
 }
 }

--- a/hedgehog/src/core/abstractions/node/task_outputs_management_abstraction.h
+++ b/hedgehog/src/core/abstractions/node/task_outputs_management_abstraction.h
@@ -72,6 +72,11 @@ class TaskOutputsManagementAbstraction : public NotifierAbstraction, public Send
     static_cast<NotifierAbstraction *>(this)->notify();
   }
 
+  template<tool::ContainsConcept<Outputs...> OutputDataType>
+  void batchSendAndNotify(std::vector<std::shared_ptr<OutputDataType>> const &data) {
+    static_cast<SenderAbstraction<OutputDataType> *>(this)->batchSend(data);
+    static_cast<NotifierAbstraction *>(this)->notify();
+  }
 
  protected:
   /// @brief Copy the inner structure from another task

--- a/hedgehog/src/core/abstractions/node/task_outputs_management_abstraction.h
+++ b/hedgehog/src/core/abstractions/node/task_outputs_management_abstraction.h
@@ -72,9 +72,12 @@ class TaskOutputsManagementAbstraction : public NotifierAbstraction, public Send
     static_cast<NotifierAbstraction *>(this)->notify();
   }
 
+  /// @brief Send pieces of data and notify the successors
+  /// @tparam OutputDataType Type of data
+  /// @param datas Datas to send
   template<tool::ContainsConcept<Outputs...> OutputDataType>
-  void batchSendAndNotify(std::vector<std::shared_ptr<OutputDataType>> const &data) {
-    static_cast<SenderAbstraction<OutputDataType> *>(this)->batchSend(data);
+  void batchSendAndNotify(std::vector<std::shared_ptr<OutputDataType>> const &datas) {
+    static_cast<SenderAbstraction<OutputDataType> *>(this)->batchSend(datas);
     static_cast<NotifierAbstraction *>(this)->notify();
   }
 

--- a/hedgehog/src/core/implementors/concrete_implementor/default_sender.h
+++ b/hedgehog/src/core/implementors/concrete_implementor/default_sender.h
@@ -77,6 +77,8 @@ class DefaultSender : public ImplementorSender<Output> {
     }
   }
 
+  /// @brief Send pieces of data to all connected receivers
+  /// @param datas Datas to send
   void batchSend(std::vector<std::shared_ptr<Output>> const &datas) override {
     std::lock_guard<std::mutex> lck(mutex_);
     for (auto const &receiver : *receivers_) {

--- a/hedgehog/src/core/implementors/concrete_implementor/default_sender.h
+++ b/hedgehog/src/core/implementors/concrete_implementor/default_sender.h
@@ -76,6 +76,13 @@ class DefaultSender : public ImplementorSender<Output> {
       while(!receiver->receive(data)){ cross_platform_yield(); }
     }
   }
+
+  void batchSend(std::vector<std::shared_ptr<Output>> const &datas) override {
+    std::lock_guard<std::mutex> lck(mutex_);
+    for (auto const &receiver : *receivers_) {
+      while(!receiver->batchReceive(datas)){ cross_platform_yield(); }
+    }
+  }
 };
 }
 }

--- a/hedgehog/src/core/implementors/concrete_implementor/graph/graph_receiver.h
+++ b/hedgehog/src/core/implementors/concrete_implementor/graph/graph_receiver.h
@@ -59,13 +59,6 @@ class GraphReceiver : public ImplementorReceiver<Input> {
                              "used to transfer data to input nodes.");
   }
 
-  /// @brief Returns the queue size after the last receive.
-  /// @return Queue size after the last receive.
-  [[nodiscard]] virtual size_t queueSizeAfterLastReceive() override {
-    throw std::runtime_error("It is not possible to get the number of input data from the graph receiver as it is only "
-                             "used to transfer data to input nodes.");
-  }
-
   /// @brief Do nothing, throw an error, a graph does not receive data, its input nodes do
   /// @return Nothing, throw a std::runtime_error
   /// @throw std::runtime_error It is not possible to get the number of input data from the graph receiver as it is only
@@ -116,6 +109,10 @@ class GraphReceiver : public ImplementorReceiver<Input> {
     return true;
   }
 
+  /// @brief Receive multiple pieces of data
+  /// @details Receive multiple pieces of data and transmit them to the concrete receiver implementation.
+  /// @param inputDatas Datas to transmit to the implementation
+  /// @return True if then data has been received, else false.
   bool batchReceive(std::vector<std::shared_ptr<Input>> const &datas) override {
     std::for_each(
         this->abstractReceivers_->begin(), this->abstractReceivers_->end(),

--- a/hedgehog/src/core/implementors/concrete_implementor/graph/graph_receiver.h
+++ b/hedgehog/src/core/implementors/concrete_implementor/graph/graph_receiver.h
@@ -59,6 +59,13 @@ class GraphReceiver : public ImplementorReceiver<Input> {
                              "used to transfer data to input nodes.");
   }
 
+  /// @brief Returns the queue size after the last receive.
+  /// @return Queue size after the last receive.
+  [[nodiscard]] virtual size_t queueSizeAfterLastReceive() override {
+    throw std::runtime_error("It is not possible to get the number of input data from the graph receiver as it is only "
+                             "used to transfer data to input nodes.");
+  }
+
   /// @brief Do nothing, throw an error, a graph does not receive data, its input nodes do
   /// @return Nothing, throw a std::runtime_error
   /// @throw std::runtime_error It is not possible to get the number of input data from the graph receiver as it is only

--- a/hedgehog/src/core/implementors/concrete_implementor/graph/graph_receiver.h
+++ b/hedgehog/src/core/implementors/concrete_implementor/graph/graph_receiver.h
@@ -109,6 +109,16 @@ class GraphReceiver : public ImplementorReceiver<Input> {
     return true;
   }
 
+  bool batchReceive(std::vector<std::shared_ptr<Input>> const &datas) override {
+    std::for_each(
+        this->abstractReceivers_->begin(), this->abstractReceivers_->end(),
+        [&datas](abstraction::ReceiverAbstraction<Input> *receiver) {
+          while(!receiver->batchReceive(datas)) { cross_platform_yield(); }
+        }
+    );
+    return true;
+  }
+
   /// @brief Add a sender to add to the graph input nodes
   /// @param sender Sender to add
   void addSender(abstraction::SenderAbstraction<Input> *const sender) override {

--- a/hedgehog/src/core/implementors/concrete_implementor/graph/graph_receiver.h
+++ b/hedgehog/src/core/implementors/concrete_implementor/graph/graph_receiver.h
@@ -94,11 +94,6 @@ class GraphReceiver : public ImplementorReceiver<Input> {
                              "transfer data to input nodes.");
   }
 
-  bool getInputDatas([[maybe_unused]]std::vector<std::shared_ptr<Input>> &datas, [[maybe_unused]]size_t count) override {
-    throw std::runtime_error("It is not possible to get input data from the graph receiver as it is only used to "
-                             "transfer data to input nodes.");
-  }
-
   /// @brief Do nothing, throw an error, a graph is not really connected to other nodes
   /// @return Nothing, throw a std::runtime_error
   /// @throw std::runtime_error A graph is not connected to any senders

--- a/hedgehog/src/core/implementors/concrete_implementor/graph/graph_receiver.h
+++ b/hedgehog/src/core/implementors/concrete_implementor/graph/graph_receiver.h
@@ -87,6 +87,11 @@ class GraphReceiver : public ImplementorReceiver<Input> {
                              "transfer data to input nodes.");
   }
 
+  bool getInputDatas([[maybe_unused]]std::vector<std::shared_ptr<Input>> &datas, [[maybe_unused]]size_t count) override {
+    throw std::runtime_error("It is not possible to get input data from the graph receiver as it is only used to "
+                             "transfer data to input nodes.");
+  }
+
   /// @brief Do nothing, throw an error, a graph is not really connected to other nodes
   /// @return Nothing, throw a std::runtime_error
   /// @throw std::runtime_error A graph is not connected to any senders

--- a/hedgehog/src/core/implementors/concrete_implementor/graph/graph_sender.h
+++ b/hedgehog/src/core/implementors/concrete_implementor/graph/graph_sender.h
@@ -68,6 +68,9 @@ class GraphSender : public ImplementorSender<Output> {
     throw std::runtime_error("A graph has no connected ReceiverAbstraction by itself");
   }
 
+  /// @brief Do nothing, throw an error, a graph is not really connected to other nodes
+  /// @param datas not used data
+  /// @throw std::runtime_error A graph has no connected ReceiverAbstraction by itself.
   void batchSend([[maybe_unused]] std::vector<std::shared_ptr<Output>> const &datas) override {
     throw std::runtime_error("A graph has no connected ReceiverAbstraction by itself");
   }

--- a/hedgehog/src/core/implementors/concrete_implementor/graph/graph_sender.h
+++ b/hedgehog/src/core/implementors/concrete_implementor/graph/graph_sender.h
@@ -67,6 +67,10 @@ class GraphSender : public ImplementorSender<Output> {
   void send([[maybe_unused]]std::shared_ptr<Output> data) override {
     throw std::runtime_error("A graph has no connected ReceiverAbstraction by itself");
   }
+
+  void batchSend([[maybe_unused]] std::vector<std::shared_ptr<Output>> const &datas) override {
+    throw std::runtime_error("A graph has no connected ReceiverAbstraction by itself");
+  }
 };
 }
 }

--- a/hedgehog/src/core/implementors/concrete_implementor/receiver/atomic_queue_receiver.h
+++ b/hedgehog/src/core/implementors/concrete_implementor/receiver/atomic_queue_receiver.h
@@ -180,24 +180,6 @@ class AtomicQueueReceiver : public ImplementorReceiver<Input> {
     return false;
   }
 
-  bool getInputDatas(std::vector<std::shared_ptr<Input>> &datas, size_t count) override {
-    while (consumerLock_.exchange(true, std::memory_order_acquire));
-
-    for (size_t i = 0; i < count; ++i) {
-      auto next = head_->next_.load();
-      [[unlikely]] if (next == nullptr) {
-          break;
-      }
-      auto oldFirst = head_;
-      head_ = next;
-      datas.emplace_back(std::move(head_->data_));
-      delete oldFirst;
-    }
-    queueSize_.fetch_sub(datas.size(), std::memory_order_relaxed);
-    consumerLock_.store(false, std::memory_order_release);
-    return !datas.empty();
-  }
-
   /// @brief Get the "current size" of the queue
   /// @return Current queue size
   size_t numberElementsReceived() override {

--- a/hedgehog/src/core/implementors/concrete_implementor/receiver/atomic_queue_receiver.h
+++ b/hedgehog/src/core/implementors/concrete_implementor/receiver/atomic_queue_receiver.h
@@ -133,6 +133,24 @@ class AtomicQueueReceiver : public ImplementorReceiver<Input> {
     return true;
   }
 
+  bool batchReceive(std::vector<std::shared_ptr<Input>> const &datas) override {
+    while (producerLock_.exchange(true, std::memory_order_acquire));
+
+    for (auto data : datas) {
+      assert(data != nullptr);
+      auto newNode = new Node(data);
+      tail_->next_.store(newNode);
+      tail_ = newNode;
+
+      auto oldQS = queueSize_.fetch_add(1, std::memory_order_relaxed);
+      maxQueueSize_.compare_exchange_strong(oldQS, oldQS + 1, std::memory_order_relaxed);
+    }
+
+    producerLock_.store(false, std::memory_order_release);
+
+    return true;
+  }
+
   /// @brief Get a piece of data from the atomic queue
   /// @param data Reference uses to return the piece of data
   /// @return True

--- a/hedgehog/src/core/implementors/concrete_implementor/receiver/atomic_queue_receiver.h
+++ b/hedgehog/src/core/implementors/concrete_implementor/receiver/atomic_queue_receiver.h
@@ -175,6 +175,24 @@ class AtomicQueueReceiver : public ImplementorReceiver<Input> {
     return false;
   }
 
+  bool getInputDatas(std::vector<std::shared_ptr<Input>> &datas, size_t count) override {
+    while (consumerLock_.exchange(true, std::memory_order_acquire));
+
+    for (size_t i = 0; i < count; ++i) {
+      auto next = head_->next_.load();
+      [[unlikely]] if (next == nullptr) {
+          break;
+      }
+      auto oldFirst = head_;
+      head_ = next;
+      datas.emplace_back(std::move(head_->data_));
+      delete oldFirst;
+    }
+    queueSize_.fetch_sub(datas.size(), std::memory_order_relaxed);
+    consumerLock_.store(false, std::memory_order_release);
+    return !datas.empty();
+  }
+
   /// @brief Get the "current size" of the queue
   /// @return Current queue size
   size_t numberElementsReceived() override {

--- a/hedgehog/src/core/implementors/concrete_implementor/receiver/atomic_queue_receiver.h
+++ b/hedgehog/src/core/implementors/concrete_implementor/receiver/atomic_queue_receiver.h
@@ -70,6 +70,9 @@ class AtomicQueueReceiver : public ImplementorReceiver<Input> {
   alignas(CACHE_LINE_SIZE)
   std::atomic_flag senderAccessFlag_{}; ///< Flag to protect access to the list of senders
 
+  alignas(CACHE_LINE_SIZE)
+  size_t queueSizeAfterLastReceive_ = 0; ///< Track the queue size on reception.
+
  public:
   /// @brief Default constructor
   /// @details Initialize the queue with a default node with no data (nullptr)
@@ -127,6 +130,7 @@ class AtomicQueueReceiver : public ImplementorReceiver<Input> {
 
     auto oldQS = queueSize_.fetch_add(1, std::memory_order_relaxed);
     maxQueueSize_.compare_exchange_strong(oldQS, oldQS + 1, std::memory_order_relaxed);
+    queueSizeAfterLastReceive_ = oldQS + 1;
 
     producerLock_.store(false, std::memory_order_release);
 
@@ -144,6 +148,7 @@ class AtomicQueueReceiver : public ImplementorReceiver<Input> {
 
       auto oldQS = queueSize_.fetch_add(1, std::memory_order_relaxed);
       maxQueueSize_.compare_exchange_strong(oldQS, oldQS + 1, std::memory_order_relaxed);
+      queueSizeAfterLastReceive_ = oldQS + 1;
     }
 
     producerLock_.store(false, std::memory_order_release);
@@ -203,6 +208,12 @@ class AtomicQueueReceiver : public ImplementorReceiver<Input> {
   /// @return Maximum filling size during the queue lifetime
   [[nodiscard]] size_t maxNumberElementsReceived() const override {
     return static_cast<size_t>(maxQueueSize_.load());
+  }
+
+  /// @brief Accessor to the maximum filling size during the queue lifetime
+  /// @return Maximum filling size during the queue lifetime
+  [[nodiscard]] size_t queueSizeAfterLastReceive() override {
+    return queueSizeAfterLastReceive_;
   }
 
   /// @brief Test if the receiver is empty or not

--- a/hedgehog/src/core/implementors/concrete_implementor/receiver/atomic_queue_receiver.h
+++ b/hedgehog/src/core/implementors/concrete_implementor/receiver/atomic_queue_receiver.h
@@ -70,9 +70,6 @@ class AtomicQueueReceiver : public ImplementorReceiver<Input> {
   alignas(CACHE_LINE_SIZE)
   std::atomic_flag senderAccessFlag_{}; ///< Flag to protect access to the list of senders
 
-  alignas(CACHE_LINE_SIZE)
-  size_t queueSizeAfterLastReceive_ = 0; ///< Track the queue size on reception.
-
  public:
   /// @brief Default constructor
   /// @details Initialize the queue with a default node with no data (nullptr)
@@ -130,13 +127,15 @@ class AtomicQueueReceiver : public ImplementorReceiver<Input> {
 
     auto oldQS = queueSize_.fetch_add(1, std::memory_order_relaxed);
     maxQueueSize_.compare_exchange_strong(oldQS, oldQS + 1, std::memory_order_relaxed);
-    queueSizeAfterLastReceive_ = oldQS + 1;
 
     producerLock_.store(false, std::memory_order_release);
 
     return true;
   }
 
+  /// @brief Store pieces of data in the atomic queue
+  /// @param datas Data to store
+  /// @return True
   bool batchReceive(std::vector<std::shared_ptr<Input>> const &datas) override {
     while (producerLock_.exchange(true, std::memory_order_acquire));
 
@@ -148,7 +147,6 @@ class AtomicQueueReceiver : public ImplementorReceiver<Input> {
 
       auto oldQS = queueSize_.fetch_add(1, std::memory_order_relaxed);
       maxQueueSize_.compare_exchange_strong(oldQS, oldQS + 1, std::memory_order_relaxed);
-      queueSizeAfterLastReceive_ = oldQS + 1;
     }
 
     producerLock_.store(false, std::memory_order_release);
@@ -190,12 +188,6 @@ class AtomicQueueReceiver : public ImplementorReceiver<Input> {
   /// @return Maximum filling size during the queue lifetime
   [[nodiscard]] size_t maxNumberElementsReceived() const override {
     return static_cast<size_t>(maxQueueSize_.load());
-  }
-
-  /// @brief Accessor to the maximum filling size during the queue lifetime
-  /// @return Maximum filling size during the queue lifetime
-  [[nodiscard]] size_t queueSizeAfterLastReceive() override {
-    return queueSizeAfterLastReceive_;
   }
 
   /// @brief Test if the receiver is empty or not

--- a/hedgehog/src/core/implementors/concrete_implementor/receiver/limited_atomic_queue_receiver.h
+++ b/hedgehog/src/core/implementors/concrete_implementor/receiver/limited_atomic_queue_receiver.h
@@ -83,9 +83,6 @@ class LimitedAtomicQueueReceiver : public ImplementorReceiver<Input> {
   alignas(CACHE_LINE_SIZE)
   std::atomic_flag senderAccessFlag_{}; ///< Flag to protect access to the list of senders
 
-  alignas(CACHE_LINE_SIZE)
-  size_t queueSizeAfterLastReceive_ = 0; ///< Track the queue size on reception.
-
  public:
   /// @brief Default constructor
   LimitedAtomicQueueReceiver() : senders_(std::make_unique<std::set<abstraction::SenderAbstraction<Input> *>>()) {}
@@ -131,11 +128,14 @@ class LimitedAtomicQueueReceiver : public ImplementorReceiver<Input> {
     if (diff > 0) {
       auto const prevSize = static_cast<size_t>(diff);
       if (prevSize > maxSize_.load(std::memory_order_acquire)) { maxSize_.store(prevSize, std::memory_order_release); }
-      queueSizeAfterLastReceive_ = prevSize;
     }
     return true;
   }
 
+  /// @brief Receive pieces of data to store it in the limited queue
+  /// @warning The storage may fail, the function returns then false
+  /// @param datas Datas to store
+  /// @return True if the data has been stored, else false
   bool batchReceive([[maybe_unused]] std::vector<std::shared_ptr<Input>> const &datas) override {
     for (auto data : datas) {
       receive(data);
@@ -182,10 +182,6 @@ class LimitedAtomicQueueReceiver : public ImplementorReceiver<Input> {
   /// @brief Accessor to the maximum filling size during the queue lifetime
   /// @return Maximum filling size during the queue lifetime
   [[nodiscard]] size_t maxNumberElementsReceived() const override { return maxSize_.load(std::memory_order_relaxed); }
-
-  /// @brief Accessor to the maximum number of data waiting to be processed in the queue during the whole execution
-  /// @return Maximum number of data waiting to be processed in the queue during the whole execution
-  [[nodiscard]] virtual size_t queueSizeAfterLastReceive() override { return queueSizeAfterLastReceive_; }
 
   /// @brief Test if the receiver is empty or not
   /// @return True if the receiver is empty, else false

--- a/hedgehog/src/core/implementors/concrete_implementor/receiver/limited_atomic_queue_receiver.h
+++ b/hedgehog/src/core/implementors/concrete_implementor/receiver/limited_atomic_queue_receiver.h
@@ -153,6 +153,12 @@ class LimitedAtomicQueueReceiver : public ImplementorReceiver<Input> {
     }
   }
 
+  // this one is not supported here
+  bool getInputDatas(std::vector<std::shared_ptr<Input>> &datas, [[maybe_unused]] size_t count) override {
+      datas.resize(1, nullptr);
+      return getInputData(datas[0]);
+  }
+
   /// @brief Get the "current size" of the queue
   /// @details Current size is deduced from the head and tail pointers, both atomic values.
   /// @return Current queue size

--- a/hedgehog/src/core/implementors/concrete_implementor/receiver/limited_atomic_queue_receiver.h
+++ b/hedgehog/src/core/implementors/concrete_implementor/receiver/limited_atomic_queue_receiver.h
@@ -137,7 +137,10 @@ class LimitedAtomicQueueReceiver : public ImplementorReceiver<Input> {
   }
 
   bool batchReceive([[maybe_unused]] std::vector<std::shared_ptr<Input>> const &datas) override {
-    throw std::runtime_error("LimitedAtomicQueueReceiver does not support batchReceive.");
+    for (auto data : datas) {
+      receive(data);
+    }
+    return true;
   }
 
   /// @brief Get a piece of data from the limited queue

--- a/hedgehog/src/core/implementors/concrete_implementor/receiver/limited_atomic_queue_receiver.h
+++ b/hedgehog/src/core/implementors/concrete_implementor/receiver/limited_atomic_queue_receiver.h
@@ -83,6 +83,9 @@ class LimitedAtomicQueueReceiver : public ImplementorReceiver<Input> {
   alignas(CACHE_LINE_SIZE)
   std::atomic_flag senderAccessFlag_{}; ///< Flag to protect access to the list of senders
 
+  alignas(CACHE_LINE_SIZE)
+  size_t queueSizeAfterLastReceive_ = 0; ///< Track the queue size on reception.
+
  public:
   /// @brief Default constructor
   LimitedAtomicQueueReceiver() : senders_(std::make_unique<std::set<abstraction::SenderAbstraction<Input> *>>()) {}
@@ -128,6 +131,7 @@ class LimitedAtomicQueueReceiver : public ImplementorReceiver<Input> {
     if (diff > 0) {
       auto const prevSize = static_cast<size_t>(diff);
       if (prevSize > maxSize_.load(std::memory_order_acquire)) { maxSize_.store(prevSize, std::memory_order_release); }
+      queueSizeAfterLastReceive_ = prevSize;
     }
     return true;
   }
@@ -181,6 +185,10 @@ class LimitedAtomicQueueReceiver : public ImplementorReceiver<Input> {
   /// @brief Accessor to the maximum filling size during the queue lifetime
   /// @return Maximum filling size during the queue lifetime
   [[nodiscard]] size_t maxNumberElementsReceived() const override { return maxSize_.load(std::memory_order_relaxed); }
+
+  /// @brief Accessor to the maximum number of data waiting to be processed in the queue during the whole execution
+  /// @return Maximum number of data waiting to be processed in the queue during the whole execution
+  [[nodiscard]] virtual size_t queueSizeAfterLastReceive() override { return queueSizeAfterLastReceive_; }
 
   /// @brief Test if the receiver is empty or not
   /// @return True if the receiver is empty, else false

--- a/hedgehog/src/core/implementors/concrete_implementor/receiver/limited_atomic_queue_receiver.h
+++ b/hedgehog/src/core/implementors/concrete_implementor/receiver/limited_atomic_queue_receiver.h
@@ -132,6 +132,10 @@ class LimitedAtomicQueueReceiver : public ImplementorReceiver<Input> {
     return true;
   }
 
+  bool batchReceive([[maybe_unused]] std::vector<std::shared_ptr<Input>> const &datas) override {
+    throw std::runtime_error("LimitedAtomicQueueReceiver does not support batchReceive.");
+  }
+
   /// @brief Get a piece of data from the limited queue
   /// @warning The operation may fail, the function returns then false
   /// @param data Reference uses to return the piece of data

--- a/hedgehog/src/core/implementors/concrete_implementor/receiver/limited_atomic_queue_receiver.h
+++ b/hedgehog/src/core/implementors/concrete_implementor/receiver/limited_atomic_queue_receiver.h
@@ -160,12 +160,6 @@ class LimitedAtomicQueueReceiver : public ImplementorReceiver<Input> {
     }
   }
 
-  // this one is not supported here
-  bool getInputDatas(std::vector<std::shared_ptr<Input>> &datas, [[maybe_unused]] size_t count) override {
-      datas.resize(1, nullptr);
-      return getInputData(datas[0]);
-  }
-
   /// @brief Get the "current size" of the queue
   /// @details Current size is deduced from the head and tail pointers, both atomic values.
   /// @return Current queue size

--- a/hedgehog/src/core/implementors/concrete_implementor/receiver/queue_receiver.h
+++ b/hedgehog/src/core/implementors/concrete_implementor/receiver/queue_receiver.h
@@ -49,7 +49,6 @@ class QueueReceiver : public ImplementorReceiver<Input> {
       senders_ = nullptr; ///< List of senders attached to this receiver
 
   size_t maxSize_ = 0; ///< Maximum size attained by the queue
-  size_t queueSizeAfterLastReceive_ = 0; ///< Track the queue size on reception.
 
   std::mutex
     queueMutex_{}, ///< Mutex protecting the queue from multiple access
@@ -71,17 +70,18 @@ class QueueReceiver : public ImplementorReceiver<Input> {
     std::lock_guard<std::mutex> lck(queueMutex_);
     queue_->push(data);
     maxSize_ = std::max(queue_->size(), maxSize_);
-    queueSizeAfterLastReceive_ = queue_->size();
     return true;
   }
 
+  /// @brief Receive datas and store them in the queue (only lock the queue once)
+  /// @param datas Datas to store
+  /// @return True
   bool batchReceive(std::vector<std::shared_ptr<Input>> const &datas) final {
     std::lock_guard<std::mutex> lck(queueMutex_);
     for (auto data : datas) {
         queue_->push(data);
     }
     maxSize_ = std::max(queue_->size(), maxSize_);
-    queueSizeAfterLastReceive_ = queue_->size();
     return true;
   }
 
@@ -106,10 +106,6 @@ class QueueReceiver : public ImplementorReceiver<Input> {
 //    std::lock_guard<std::mutex> lck(sendersMutex_);
     return queue_->size();
   }
-
-  /// @brief Accessor to the maximum number of data waiting to be processed in the queue during the whole execution
-  /// @return Maximum number of data waiting to be processed in the queue during the whole execution
-  [[nodiscard]] size_t queueSizeAfterLastReceive() override { return queueSizeAfterLastReceive_; }
 
   /// @brief Accessor to the maximum queue size
   /// @return Maximum queue size

--- a/hedgehog/src/core/implementors/concrete_implementor/receiver/queue_receiver.h
+++ b/hedgehog/src/core/implementors/concrete_implementor/receiver/queue_receiver.h
@@ -100,15 +100,6 @@ class QueueReceiver : public ImplementorReceiver<Input> {
     return ret;
   }
 
-  [[nodiscard]] bool getInputDatas(std::vector<std::shared_ptr<Input>> &datas, size_t count) override {
-    std::lock_guard<std::mutex> lck(queueMutex_);
-    for (size_t i = 0; i < count && !queue_->empty(); ++i) {
-      datas.emplace_back(std::move(queue_->front()));
-      queue_->pop();
-    }
-    return !datas.empty();
-  }
-
   /// @brief Accessor to the current size of the queue
   /// @return Current size of the queue
   [[nodiscard]] size_t numberElementsReceived() override {

--- a/hedgehog/src/core/implementors/concrete_implementor/receiver/queue_receiver.h
+++ b/hedgehog/src/core/implementors/concrete_implementor/receiver/queue_receiver.h
@@ -73,6 +73,15 @@ class QueueReceiver : public ImplementorReceiver<Input> {
     return true;
   }
 
+  bool batchReceive(std::vector<std::shared_ptr<Input>> const &datas) final {
+    std::lock_guard<std::mutex> lck(queueMutex_);
+    for (auto data : datas) {
+        queue_->push(data);
+    }
+    maxSize_ = std::max(queue_->size(), maxSize_);
+    return true;
+  }
+
   /// @brief Get a data from the queue
   /// @warning The queue should not be empty
   /// @param data Data to get from the queue

--- a/hedgehog/src/core/implementors/concrete_implementor/receiver/queue_receiver.h
+++ b/hedgehog/src/core/implementors/concrete_implementor/receiver/queue_receiver.h
@@ -97,6 +97,15 @@ class QueueReceiver : public ImplementorReceiver<Input> {
     return ret;
   }
 
+  [[nodiscard]] bool getInputDatas(std::vector<std::shared_ptr<Input>> &datas, size_t count) override {
+    std::lock_guard<std::mutex> lck(queueMutex_);
+    for (size_t i = 0; i < count && !queue_->empty(); ++i) {
+      datas.emplace_back(std::move(queue_->front()));
+      queue_->pop();
+    }
+    return !datas.empty();
+  }
+
   /// @brief Accessor to the current size of the queue
   /// @return Current size of the queue
   [[nodiscard]] size_t numberElementsReceived() override {

--- a/hedgehog/src/core/implementors/concrete_implementor/receiver/queue_receiver.h
+++ b/hedgehog/src/core/implementors/concrete_implementor/receiver/queue_receiver.h
@@ -49,6 +49,7 @@ class QueueReceiver : public ImplementorReceiver<Input> {
       senders_ = nullptr; ///< List of senders attached to this receiver
 
   size_t maxSize_ = 0; ///< Maximum size attained by the queue
+  size_t queueSizeAfterLastReceive_ = 0; ///< Track the queue size on reception.
 
   std::mutex
     queueMutex_{}, ///< Mutex protecting the queue from multiple access
@@ -70,6 +71,7 @@ class QueueReceiver : public ImplementorReceiver<Input> {
     std::lock_guard<std::mutex> lck(queueMutex_);
     queue_->push(data);
     maxSize_ = std::max(queue_->size(), maxSize_);
+    queueSizeAfterLastReceive_ = queue_->size();
     return true;
   }
 
@@ -79,6 +81,7 @@ class QueueReceiver : public ImplementorReceiver<Input> {
         queue_->push(data);
     }
     maxSize_ = std::max(queue_->size(), maxSize_);
+    queueSizeAfterLastReceive_ = queue_->size();
     return true;
   }
 
@@ -112,6 +115,10 @@ class QueueReceiver : public ImplementorReceiver<Input> {
 //    std::lock_guard<std::mutex> lck(sendersMutex_);
     return queue_->size();
   }
+
+  /// @brief Accessor to the maximum number of data waiting to be processed in the queue during the whole execution
+  /// @return Maximum number of data waiting to be processed in the queue during the whole execution
+  [[nodiscard]] size_t queueSizeAfterLastReceive() override { return queueSizeAfterLastReceive_; }
 
   /// @brief Accessor to the maximum queue size
   /// @return Maximum queue size

--- a/hedgehog/src/core/implementors/implementor/implementor_receiver.h
+++ b/hedgehog/src/core/implementors/implementor/implementor_receiver.h
@@ -91,6 +91,8 @@ class ImplementorReceiver {
   /// @return True if the piece of data has been received, else false.
   virtual bool receive(std::shared_ptr<Input> data) = 0;
 
+  virtual bool batchReceive(std::vector<std::shared_ptr<Input>> const &datas) = 0;
+
   /// @brief Get an input data
   /// @details If a data is available, it is placed in data
   /// @param data Reference to the data to get from the receiver

--- a/hedgehog/src/core/implementors/implementor/implementor_receiver.h
+++ b/hedgehog/src/core/implementors/implementor/implementor_receiver.h
@@ -99,6 +99,8 @@ class ImplementorReceiver {
   /// @return True if a data is available, else false
   [[nodiscard]] virtual bool getInputData(std::shared_ptr<Input> &data) = 0;
 
+  [[nodiscard]] virtual bool getInputDatas(std::vector<std::shared_ptr<Input>> &datas, size_t count) = 0;
+
   /// @brief Accessor to number of data waiting to be processed in the queue
   /// @return Number of data waiting to be processed in the queue
   [[nodiscard]] virtual size_t numberElementsReceived() = 0;

--- a/hedgehog/src/core/implementors/implementor/implementor_receiver.h
+++ b/hedgehog/src/core/implementors/implementor/implementor_receiver.h
@@ -105,6 +105,10 @@ class ImplementorReceiver {
   /// @return Number of data waiting to be processed in the queue
   [[nodiscard]] virtual size_t numberElementsReceived() = 0;
 
+  /// @brief Returns the queue size after the last receive.
+  /// @return Queue size after the last receive.
+  [[nodiscard]] virtual size_t queueSizeAfterLastReceive() = 0;
+
   /// @brief Accessor to the maximum number of data waiting to be processed in the queue during the whole execution
   /// @return Maximum number of data waiting to be processed in the queue during the whole execution
   [[nodiscard]] virtual size_t maxNumberElementsReceived() const = 0;

--- a/hedgehog/src/core/implementors/implementor/implementor_receiver.h
+++ b/hedgehog/src/core/implementors/implementor/implementor_receiver.h
@@ -99,8 +99,6 @@ class ImplementorReceiver {
   /// @return True if a data is available, else false
   [[nodiscard]] virtual bool getInputData(std::shared_ptr<Input> &data) = 0;
 
-  [[nodiscard]] virtual bool getInputDatas(std::vector<std::shared_ptr<Input>> &datas, size_t count) = 0;
-
   /// @brief Accessor to number of data waiting to be processed in the queue
   /// @return Number of data waiting to be processed in the queue
   [[nodiscard]] virtual size_t numberElementsReceived() = 0;

--- a/hedgehog/src/core/implementors/implementor/implementor_receiver.h
+++ b/hedgehog/src/core/implementors/implementor/implementor_receiver.h
@@ -91,6 +91,10 @@ class ImplementorReceiver {
   /// @return True if the piece of data has been received, else false.
   virtual bool receive(std::shared_ptr<Input> data) = 0;
 
+  /// @brief Batch receive data interface
+  /// @details Batch reception allow locking the queues only once for receiving mulitple items which can be more optimized in some situation.
+  /// @param datas Datas received by the core
+  /// @return True if the datas have been received, else false.
   virtual bool batchReceive(std::vector<std::shared_ptr<Input>> const &datas) = 0;
 
   /// @brief Get an input data
@@ -102,10 +106,6 @@ class ImplementorReceiver {
   /// @brief Accessor to number of data waiting to be processed in the queue
   /// @return Number of data waiting to be processed in the queue
   [[nodiscard]] virtual size_t numberElementsReceived() = 0;
-
-  /// @brief Returns the queue size after the last receive.
-  /// @return Queue size after the last receive.
-  [[nodiscard]] virtual size_t queueSizeAfterLastReceive() = 0;
 
   /// @brief Accessor to the maximum number of data waiting to be processed in the queue during the whole execution
   /// @return Maximum number of data waiting to be processed in the queue during the whole execution

--- a/hedgehog/src/core/implementors/implementor/implementor_sender.h
+++ b/hedgehog/src/core/implementors/implementor/implementor_sender.h
@@ -78,6 +78,8 @@ class ImplementorSender {
   /// @param data Data to send
   virtual void send(std::shared_ptr<Output> data) = 0;
 
+  /// @brief Send datas to successor node
+  /// @param datas Datas to send
   virtual void batchSend(std::vector<std::shared_ptr<Output>> const &datas) = 0;
 };
 }

--- a/hedgehog/src/core/implementors/implementor/implementor_sender.h
+++ b/hedgehog/src/core/implementors/implementor/implementor_sender.h
@@ -77,6 +77,8 @@ class ImplementorSender {
   /// @brief Send a data to successor node
   /// @param data Data to send
   virtual void send(std::shared_ptr<Output> data) = 0;
+
+  virtual void batchSend(std::vector<std::shared_ptr<Output>> const &datas) = 0;
 };
 }
 }

--- a/hedgehog/src/core/nodes/core_state_manager.h
+++ b/hedgehog/src/core/nodes/core_state_manager.h
@@ -86,6 +86,8 @@ class CoreStateManager
   bool const
       automaticStart_ = false; ///< Flag for automatic start
 
+  tool::BatchOutputVectors_t<Separator, AllTypes...> batchOutputBuffers_;
+
  public:
   /// @brief Construct a state manager from the user state manager and its state
   /// @param stateManager User-defined state manager
@@ -306,7 +308,6 @@ class CoreStateManager
   }
 
  private:
-
   /// @brief Gather the state manager and the state into the cleanableSet
   /// @param cleanableSet Set of cleanable nodes
   void gatherCleanable(std::unordered_set<hh::behavior::Cleanable *> &cleanableSet) override {
@@ -326,13 +327,15 @@ class CoreStateManager
   /// @tparam Output Ready list output type
   template<class Output>
   void emptyReadyLists() {
+    auto &datas = std::get<std::vector<std::shared_ptr<Output>>>(batchOutputBuffers_);
     auto &rdyList = std::static_pointer_cast<behavior::StateSender<Output>>(state_)->readyList();
-    std::shared_ptr<Output> data = nullptr;
+
     while (!rdyList->empty()) {
-      data = rdyList->front();
-      rdyList->pop();
-      this->sendAndNotify(data);
+        datas.push_back(rdyList->front());
+        rdyList->pop();
     }
+    this->batchSendAndNotify(datas);
+    datas.clear();
   }
 
   /// @brief Clone method, to duplicate a state manager when it is part of another graph in an execution pipeline

--- a/hedgehog/src/core/nodes/core_state_manager.h
+++ b/hedgehog/src/core/nodes/core_state_manager.h
@@ -298,10 +298,7 @@ class CoreStateManager
   /// @brief Accessor to user-defined extra information for the state-manager
   /// @return User-defined extra information for the state-manager
   [[nodiscard]] std::string extraPrintingInformation() const override {
-    std::ostringstream oss;
-    oss << this->receiversExtraPrintingInformation() << "-------\n";
-    oss << this->stateManager_->extraPrintingInformation();
-    return oss.str();
+    return this->stateManager_->extraPrintingInformation();
   }
 
   /// @brief Accessor to the memory manager

--- a/hedgehog/src/core/nodes/core_state_manager.h
+++ b/hedgehog/src/core/nodes/core_state_manager.h
@@ -298,7 +298,10 @@ class CoreStateManager
   /// @brief Accessor to user-defined extra information for the state-manager
   /// @return User-defined extra information for the state-manager
   [[nodiscard]] std::string extraPrintingInformation() const override {
-    return this->stateManager_->extraPrintingInformation();
+    std::ostringstream oss;
+    oss << this->receiversExtraPrintingInformation() << "-------\n";
+    oss << this->stateManager_->extraPrintingInformation();
+    return oss.str();
   }
 
   /// @brief Accessor to the memory manager

--- a/hedgehog/src/core/nodes/core_state_manager.h
+++ b/hedgehog/src/core/nodes/core_state_manager.h
@@ -86,7 +86,8 @@ class CoreStateManager
   bool const
       automaticStart_ = false; ///< Flag for automatic start
 
-  tool::BatchOutputVectors_t<Separator, AllTypes...> batchOutputBuffers_;
+  tool::BatchOutputVectors_t<Separator, AllTypes...>
+      batchOutputBuffers_; ///< Buffer used for batch send, stored here to limit allocations.
 
  public:
   /// @brief Construct a state manager from the user state manager and its state
@@ -335,6 +336,12 @@ class CoreStateManager
     }
 
     while (!rdyList->empty()) {
+        // NOTE(RC): Since we don't have a way to predict the required buffer
+        // size before hand, we allow the buffer to grow here, however, it has
+        // to be a class member to avoid reallocation each time this function
+        // is called. Another solution would be to use a
+        // `std::pmr::monotonic_buffer_resource` to allocated a temporary
+        // vector on the stack, but I'm not sure that it is worth it in this case.
         datas.push_back(rdyList->front());
         rdyList->pop();
     }

--- a/hedgehog/src/core/nodes/core_state_manager.h
+++ b/hedgehog/src/core/nodes/core_state_manager.h
@@ -330,6 +330,10 @@ class CoreStateManager
     auto &datas = std::get<std::vector<std::shared_ptr<Output>>>(batchOutputBuffers_);
     auto &rdyList = std::static_pointer_cast<behavior::StateSender<Output>>(state_)->readyList();
 
+    if (rdyList->empty()) {
+        return;
+    }
+
     while (!rdyList->empty()) {
         datas.push_back(rdyList->front());
         rdyList->pop();

--- a/hedgehog/src/core/nodes/core_task.h
+++ b/hedgehog/src/core/nodes/core_task.h
@@ -203,7 +203,7 @@ class CoreTask
       if (canTerminate) { break; }
 
       // Operate the connectedReceivers to get a data and send it to execute
-      this->operateReceivers(this->numberThreads());
+      this->operateReceivers();
     }
 
     // Do the shutdown phase

--- a/hedgehog/src/core/nodes/core_task.h
+++ b/hedgehog/src/core/nodes/core_task.h
@@ -203,7 +203,7 @@ class CoreTask
       if (canTerminate) { break; }
 
       // Operate the connectedReceivers to get a data and send it to execute
-      this->operateReceivers();
+      this->operateReceivers(this->numberThreads());
     }
 
     // Do the shutdown phase

--- a/hedgehog/src/core/nodes/core_task.h
+++ b/hedgehog/src/core/nodes/core_task.h
@@ -293,10 +293,7 @@ class CoreTask
   /// @brief Accessor to user-defined extra information for the task
   /// @return User-defined extra information for the task
   [[nodiscard]] std::string extraPrintingInformation() const override {
-    std::ostringstream oss;
-    oss << this->receiversExtraPrintingInformation() << "-------\n";
-    oss << this->task_->extraPrintingInformation();
-    return oss.str();
+    return this->task_->extraPrintingInformation();
   }
 
   /// @brief Copy task's inner structure

--- a/hedgehog/src/core/nodes/core_task.h
+++ b/hedgehog/src/core/nodes/core_task.h
@@ -293,7 +293,10 @@ class CoreTask
   /// @brief Accessor to user-defined extra information for the task
   /// @return User-defined extra information for the task
   [[nodiscard]] std::string extraPrintingInformation() const override {
-    return this->task_->extraPrintingInformation();
+    std::ostringstream oss;
+    oss << this->receiversExtraPrintingInformation() << "-------\n";
+    oss << this->task_->extraPrintingInformation();
+    return oss.str();
   }
 
   /// @brief Copy task's inner structure

--- a/hedgehog/src/core/parts/graph_source.h
+++ b/hedgehog/src/core/parts/graph_source.h
@@ -63,6 +63,12 @@ class GraphSource :
     static_cast<NotifierAbstraction *>(this)->notify();
   }
 
+  template<class Input>
+  void batchSendAndNotifyAllInputs(std::vector<std::shared_ptr<Input>> const &datas) {
+    static_cast<abstraction::SenderAbstraction<Input> *>(this)->batchSend(datas);
+    static_cast<NotifierAbstraction *>(this)->notify();
+  }
+
   /// @brief Gather source information
   /// @param printer Printer visitor gathering information on nodes
   void print(Printer *printer) {

--- a/hedgehog/src/core/parts/graph_source.h
+++ b/hedgehog/src/core/parts/graph_source.h
@@ -63,6 +63,9 @@ class GraphSource :
     static_cast<NotifierAbstraction *>(this)->notify();
   }
 
+  /// @brief Send pieces of data to all input nodes and notify them
+  /// @tparam Input Input data type
+  /// @param datas Input datas
   template<class Input>
   void batchSendAndNotifyAllInputs(std::vector<std::shared_ptr<Input>> const &datas) {
     static_cast<abstraction::SenderAbstraction<Input> *>(this)->batchSend(datas);

--- a/hedgehog/src/tools/meta_functions.h
+++ b/hedgehog/src/tools/meta_functions.h
@@ -278,14 +278,21 @@ constexpr auto typeToStrView() {
 template<typename T>
 constexpr auto typeToStr() { return std::string(typeToStrView<T>()); }
 
+/// @brief BatchOutputVectorsTypeImpl declaration.
+/// @tparam TypeList List of types.
 template <typename TypeList>
 struct BatchOutputVectorsTypeImpl;
 
+/// @brief BatchOutputVectorsTypeImpl implementation for tuple.
+/// @tparam Outputs List of output types.
 template <typename ...Outputs>
 struct BatchOutputVectorsTypeImpl<std::tuple<Outputs...>> {
     using type = std::tuple<std::vector<std::shared_ptr<Outputs>>...>;
 };
 
+/// @brief Create the type of a tuple of vectors of output data (used by the core state).
+/// @tparam Separator Separator position between input types and output types
+/// @tparam AllTypes List of input and output types
 template <size_t Separator, typename ...AllTypes>
 using BatchOutputVectors_t = typename BatchOutputVectorsTypeImpl<Outputs<Separator, AllTypes...>>::type;
 

--- a/hedgehog/src/tools/meta_functions.h
+++ b/hedgehog/src/tools/meta_functions.h
@@ -238,9 +238,9 @@ struct LambdaContainerDeducer;
 /// @tparam LambdaTaskType Type of the lambda task (CRTP)
 /// @tparam Inputs Input types of the lambda task
 template<class LambdaTaskType, class ...Inputs>
-struct LambdaContainerDeducer<LambdaTaskType, std::tuple<Inputs...>> { 
+struct LambdaContainerDeducer<LambdaTaskType, std::tuple<Inputs...>> {
     /// @brief Accessor to the type of the lambda container
-    using type = LambdaContainer<LambdaTaskType, Inputs...>; 
+    using type = LambdaContainer<LambdaTaskType, Inputs...>;
 };
 
 /// @brief Helper that gives the type of the lambda container in a lambda task
@@ -277,6 +277,17 @@ constexpr auto typeToStrView() {
 /// @return String containing the name of the type
 template<typename T>
 constexpr auto typeToStr() { return std::string(typeToStrView<T>()); }
+
+template <typename TypeList>
+struct BatchOutputVectorsTypeImpl;
+
+template <typename ...Outputs>
+struct BatchOutputVectorsTypeImpl<std::tuple<Outputs...>> {
+    using type = std::tuple<std::vector<std::shared_ptr<Outputs>>...>;
+};
+
+template <size_t Separator, typename ...AllTypes>
+using BatchOutputVectors_t = typename BatchOutputVectorsTypeImpl<Outputs<Separator, AllTypes...>>::type;
 
 }
 }

--- a/hedgehog/src/tools/task_interface.h
+++ b/hedgehog/src/tools/task_interface.h
@@ -49,6 +49,12 @@ class TaskInterface {
       task_->addResult(data);
   }
 
+  /// @brief Exposes LambdaTask::batchAddResult
+  template <class T>
+  void batchAddResult(std::vector<std::shared_ptr<T>> const& data) {
+      task_->batchAddResult(data);
+  }
+
   /// @brief Exposes LambdaTask::getManagedMemory
   [[nodiscard]] std::shared_ptr<ManagedMemory> getManagedMemory() { return task_->getManagedMemory(); }
 

--- a/tests/data_structures/implementors/priority_queue_receiver.h
+++ b/tests/data_structures/implementors/priority_queue_receiver.h
@@ -63,6 +63,14 @@ class PriorityQueueReceiver : public hh::core::implementor::ImplementorReceiver<
     queue_->pop();
     return true;
   }
+  [[nodiscard]] bool getInputDatas(std::vector<std::shared_ptr<Input>> &datas, size_t count) override {
+    std::lock_guard<std::mutex> lck(queueMutex_);
+    for (size_t i = 0; i < count && !queue_->empty(); ++i) {
+        datas.emplace_back(std::move(queue_->top()));
+        queue_->pop();
+    }
+    return !datas.empty();
+  }
   [[nodiscard]] size_t numberElementsReceived() override {
     std::lock_guard<std::mutex> lck(queueMutex_);
     return queue_->size();

--- a/tests/data_structures/implementors/priority_queue_receiver.h
+++ b/tests/data_structures/implementors/priority_queue_receiver.h
@@ -48,6 +48,14 @@ class PriorityQueueReceiver : public hh::core::implementor::ImplementorReceiver<
     maxSize_ = std::max(queue_->size(), maxSize_);
     return true;
   }
+  bool batchReceive(std::vector<std::shared_ptr<Input>> const &datas) final {
+    std::lock_guard<std::mutex> lck(queueMutex_);
+    for (auto data : datas) {
+      queue_->push(data);
+    }
+    maxSize_ = std::max(queue_->size(), maxSize_);
+    return true;
+  }
   [[nodiscard]] bool getInputData(std::shared_ptr<Input> &data) override {
     std::lock_guard<std::mutex> lck(queueMutex_);
     assert(!queue_->empty());

--- a/tests/data_structures/implementors/priority_queue_receiver.h
+++ b/tests/data_structures/implementors/priority_queue_receiver.h
@@ -67,14 +67,6 @@ class PriorityQueueReceiver : public hh::core::implementor::ImplementorReceiver<
     queue_->pop();
     return true;
   }
-  [[nodiscard]] bool getInputDatas(std::vector<std::shared_ptr<Input>> &datas, size_t count) override {
-    std::lock_guard<std::mutex> lck(queueMutex_);
-    for (size_t i = 0; i < count && !queue_->empty(); ++i) {
-        datas.emplace_back(std::move(queue_->top()));
-        queue_->pop();
-    }
-    return !datas.empty();
-  }
   [[nodiscard]] size_t numberElementsReceived() override {
     std::lock_guard<std::mutex> lck(queueMutex_);
     return queue_->size();

--- a/tests/data_structures/implementors/priority_queue_receiver.h
+++ b/tests/data_structures/implementors/priority_queue_receiver.h
@@ -36,6 +36,8 @@ class PriorityQueueReceiver : public hh::core::implementor::ImplementorReceiver<
 
   size_t
       maxSize_ = 0; ///< Maximum size attained by the queue
+  size_t
+      queueSizeAfterLastReceive_ = 0; ///< Track the queue size on reception.
 
   std::mutex queueMutex_{}, sendersMutex_{};
  public:
@@ -46,6 +48,7 @@ class PriorityQueueReceiver : public hh::core::implementor::ImplementorReceiver<
     std::lock_guard<std::mutex> lck(queueMutex_);
     queue_->push(data);
     maxSize_ = std::max(queue_->size(), maxSize_);
+    queueSizeAfterLastReceive_ = queue_->size();
     return true;
   }
   bool batchReceive(std::vector<std::shared_ptr<Input>> const &datas) final {
@@ -54,6 +57,7 @@ class PriorityQueueReceiver : public hh::core::implementor::ImplementorReceiver<
       queue_->push(data);
     }
     maxSize_ = std::max(queue_->size(), maxSize_);
+    queueSizeAfterLastReceive_ = queue_->size();
     return true;
   }
   [[nodiscard]] bool getInputData(std::shared_ptr<Input> &data) override {
@@ -75,6 +79,7 @@ class PriorityQueueReceiver : public hh::core::implementor::ImplementorReceiver<
     std::lock_guard<std::mutex> lck(queueMutex_);
     return queue_->size();
   }
+  [[nodiscard]] size_t queueSizeAfterLastReceive() override { return queueSizeAfterLastReceive_; }
   [[nodiscard]] size_t maxNumberElementsReceived() const override { return maxSize_; }
 
   [[nodiscard]] bool empty() override {

--- a/tests/data_structures/implementors/priority_queue_receiver.h
+++ b/tests/data_structures/implementors/priority_queue_receiver.h
@@ -36,8 +36,6 @@ class PriorityQueueReceiver : public hh::core::implementor::ImplementorReceiver<
 
   size_t
       maxSize_ = 0; ///< Maximum size attained by the queue
-  size_t
-      queueSizeAfterLastReceive_ = 0; ///< Track the queue size on reception.
 
   std::mutex queueMutex_{}, sendersMutex_{};
  public:
@@ -48,7 +46,6 @@ class PriorityQueueReceiver : public hh::core::implementor::ImplementorReceiver<
     std::lock_guard<std::mutex> lck(queueMutex_);
     queue_->push(data);
     maxSize_ = std::max(queue_->size(), maxSize_);
-    queueSizeAfterLastReceive_ = queue_->size();
     return true;
   }
   bool batchReceive(std::vector<std::shared_ptr<Input>> const &datas) final {
@@ -57,7 +54,6 @@ class PriorityQueueReceiver : public hh::core::implementor::ImplementorReceiver<
       queue_->push(data);
     }
     maxSize_ = std::max(queue_->size(), maxSize_);
-    queueSizeAfterLastReceive_ = queue_->size();
     return true;
   }
   [[nodiscard]] bool getInputData(std::shared_ptr<Input> &data) override {
@@ -71,7 +67,6 @@ class PriorityQueueReceiver : public hh::core::implementor::ImplementorReceiver<
     std::lock_guard<std::mutex> lck(queueMutex_);
     return queue_->size();
   }
-  [[nodiscard]] size_t queueSizeAfterLastReceive() override { return queueSizeAfterLastReceive_; }
   [[nodiscard]] size_t maxNumberElementsReceived() const override { return maxSize_; }
 
   [[nodiscard]] bool empty() override {

--- a/tests/test_hedgehog.cc
+++ b/tests/test_hedgehog.cc
@@ -23,6 +23,7 @@
 #include "tests_impl/test_state_manager.h"
 #include "tests_impl/test_memory_manager.h"
 #include "tests_impl/test_lambda_task.h"
+#include "tests_impl/test_batch_add_result.h"
 
 #include "tests_impl/compile_time_tests/test_basic.h"
 #include "tests_impl/compile_time_tests/test_critical_path.h"

--- a/tests/tests_impl/test_batch_add_result.h
+++ b/tests/tests_impl/test_batch_add_result.h
@@ -1,0 +1,217 @@
+// NIST-developed software is provided by NIST as a public service. You may use, copy and distribute copies of the
+// software in any medium, provided that you keep intact this entire notice. You may improve, modify and create
+// derivative works of the software or any portion of the software, and you may copy and distribute such modifications
+// or works. Modified works should carry a notice stating that you changed the software and should note the date and
+// nature of any such change. Please explicitly acknowledge the National Institute of Standards and Technology as the
+// source of the software. NIST-developed software is expressly provided "AS IS." NIST MAKES NO WARRANTY OF ANY KIND,
+// EXPRESS, IMPLIED, IN FACT OR ARISING BY OPERATION OF LAW, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTY OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT AND DATA ACCURACY. NIST NEITHER REPRESENTS NOR
+// WARRANTS THAT THE OPERATION OF THE SOFTWARE WILL BE UNINTERRUPTED OR ERROR-FREE, OR THAT ANY DEFECTS WILL BE
+// CORRECTED. NIST DOES NOT WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE OF THE SOFTWARE OR THE RESULTS
+// THEREOF, INCLUDING BUT NOT LIMITED TO THE CORRECTNESS, ACCURACY, RELIABILITY, OR USEFULNESS OF THE SOFTWARE. You
+// are solely responsible for determining the appropriateness of using and distributing the software and you assume
+// all risks associated with its use, including but not limited to the risks and costs of program errors, compliance
+// with applicable laws, damage to or loss of data, programs or equipment, and the unavailability or interruption of
+// operation. This software is not intended to be used in any situation where a failure could cause risk of injury or
+// damage to property. The software developed by NIST employees is not subject to copyright protection within the
+// United States.
+
+
+#include <gtest/gtest.h>
+#include <memory>
+#include <vector>
+#include "../../hedgehog/hedgehog.h"
+
+// Test data structure for basic test
+struct BasicData {
+    int value;
+    BasicData(int v) : value(v) {}
+};
+
+// Test data structure for complex test - multiple types
+struct IntData {
+    int value;
+    IntData(int v) : value(v) {}
+};
+
+struct DoubleData {
+    double value;
+    DoubleData(double v) : value(v) {}
+};
+
+struct StringData {
+    std::string value;
+    StringData(std::string v) : value(std::move(v)) {}
+};
+
+// Helper function to create a vector of shared pointers
+template<typename T, typename... Args>
+std::vector<std::shared_ptr<T>> makeSharedVector(Args&&... args) {
+    return {std::make_shared<T>(std::forward<Args>(args))...};
+}
+
+void batchAddResultBasicTest() {
+    // Basic test: single task with multiple results
+    hh::Graph<1, BasicData, BasicData> g;
+    auto task = std::make_shared<hh::LambdaTask<1, BasicData, BasicData>>();
+
+    // Lambda that uses batchAddResult to send multiple results
+    task->setLambda<BasicData>([](std::shared_ptr<BasicData> data, auto self) {
+        // Create multiple results to send in batch
+        auto results = makeSharedVector<BasicData>(
+            BasicData(data->value * 2),
+            BasicData(data->value * 3),
+            BasicData(data->value * 4)
+        );
+        self.batchAddResult(results);
+    });
+
+    g.inputs(task);
+    g.outputs(task);
+    g.executeGraph();
+
+    // Push test data
+    g.pushData(std::make_shared<BasicData>(5));
+    g.finishPushingData();
+
+    // Collect results
+    std::vector<std::shared_ptr<BasicData>> results;
+    while (auto res = g.getBlockingResult()) {
+        // Extract the BasicData from the tuple (single element)
+        results.push_back(std::get<0>(*res));
+    }
+
+    g.waitForTermination();
+
+    // Should have 3 results: 5*2=10, 5*3=15, 5*4=20
+    ASSERT_EQ(results.size(), 3);
+    EXPECT_EQ(results[0]->value, 10);
+    EXPECT_EQ(results[1]->value, 15);
+    EXPECT_EQ(results[2]->value, 20);
+}
+
+void batchAddResultComplexTest() {
+    // Complex test: multiple task types with multiple receivers
+    hh::Graph<3, IntData, DoubleData, StringData, IntData, DoubleData, StringData> g;
+
+    // Task 1: processes IntData and produces IntData and DoubleData
+    auto task1 = std::make_shared<hh::LambdaTask<3, IntData, DoubleData, StringData, IntData, DoubleData>>();
+    task1->setLambda<IntData>([](std::shared_ptr<IntData> data, auto self) {
+        // Batch send multiple results of different types
+        auto intResults = makeSharedVector<IntData>(
+            IntData(data->value * 2),
+            IntData(data->value * 3)
+        );
+        auto doubleResults = makeSharedVector<DoubleData>(
+            DoubleData(static_cast<double>(data->value) * 1.5),
+            DoubleData(static_cast<double>(data->value) * 2.5)
+        );
+        self.batchAddResult(intResults);    // First output type (IntData)
+        self.batchAddResult(doubleResults); // Second output type (DoubleData)
+    });
+    // Set dummy lambdas for other input types to avoid bad_function_call
+    task1->setLambda<DoubleData>([](std::shared_ptr<DoubleData>, auto) {});
+    task1->setLambda<StringData>([](std::shared_ptr<StringData>, auto) {});
+
+    // Task 2: processes DoubleData and produces StringData
+    auto task2 = std::make_shared<hh::LambdaTask<3, IntData, DoubleData, StringData, IntData, DoubleData, StringData>>();
+    task2->setLambda<DoubleData>([](std::shared_ptr<DoubleData> data, auto self) {
+        auto stringResults = makeSharedVector<StringData>(
+            StringData("double_" + std::to_string(static_cast<int>(data->value * 10))),
+            StringData("value_" + std::to_string(static_cast<int>(data->value)))
+        );
+        self.batchAddResult(stringResults); // Third output type (StringData)
+    });
+    // Set dummy lambdas for other input types to avoid bad_function_call
+    task2->setLambda<IntData>([](std::shared_ptr<IntData>, auto) {});
+    task2->setLambda<StringData>([](std::shared_ptr<StringData>, auto) {});
+
+    // Task 3: processes StringData and produces IntData
+    auto task3 = std::make_shared<hh::LambdaTask<3, IntData, DoubleData, StringData, IntData, DoubleData, StringData>>();
+    task3->setLambda<StringData>([](std::shared_ptr<StringData> data, auto self) {
+        auto intResults = makeSharedVector<IntData>(
+            IntData(static_cast<int>(data->value.length())),
+            IntData(static_cast<int>(data->value.length() * 2))
+        );
+        self.batchAddResult(intResults); // First output type (IntData)
+    });
+    // Set dummy lambdas for other input types to avoid bad_function_call
+    task3->setLambda<IntData>([](std::shared_ptr<IntData>, auto) {});
+    task3->setLambda<DoubleData>([](std::shared_ptr<DoubleData>, auto) {});
+
+    // Set up connections
+    g.inputs(task1);
+    g.edges(task1, task2); // Connect task1's DoubleData output to task2's DoubleData input
+    g.edges(task2, task3); // Connect task2's StringData output to task3's StringData input
+    // Set outputs for all tasks
+    g.outputs(task1);
+    g.outputs(task2);
+    g.outputs(task3);
+
+    g.executeGraph();
+
+    // Push initial data
+    g.pushData(std::make_shared<IntData>(5));
+    g.finishPushingData();
+
+    // Collect all results
+    std::vector<std::shared_ptr<IntData>> intResults;
+    std::vector<std::shared_ptr<DoubleData>> doubleResults;
+    std::vector<std::shared_ptr<StringData>> stringResults;
+
+    while (auto res = g.getBlockingResult()) {
+        if (auto intPtr = std::get_if<std::shared_ptr<IntData>>(&(*res))) {
+            intResults.push_back(*intPtr);
+        } else if (auto doublePtr = std::get_if<std::shared_ptr<DoubleData>>(&(*res))) {
+            doubleResults.push_back(*doublePtr);
+        } else if (auto stringPtr = std::get_if<std::shared_ptr<StringData>>(&(*res))) {
+            stringResults.push_back(*stringPtr);
+        }
+    }
+
+    g.waitForTermination();
+
+    // Verify results
+    // From initial IntData(5):
+    // Task1 produces: IntData(10), IntData(15) and DoubleData(7.5), DoubleData(12.5)
+    // Task2 processes DoubleData:
+    //   DoubleData(7.5) -> StringData("double_75"), StringData("value_7")
+    //   DoubleData(12.5) -> StringData("double_125"), StringData("value_12")
+    // Task3 processes StringData:
+    //   StringData("double_75") (length 9) -> IntData(9), IntData(18)
+    //   StringData("value_7") (length 6) -> IntData(6), IntData(12)
+    //   StringData("double_125") (length 11) -> IntData(11), IntData(22)
+    //   StringData("value_12") (length 8) -> IntData(8), IntData(16)
+
+    // We should get 2 int results from task1, 4 string results from task2, and 8 int results from task3
+    EXPECT_EQ(intResults.size(), 2 + 8); // 2 from task1, 8 from task3
+    EXPECT_EQ(doubleResults.size(), 2);  // 2 from task1
+    EXPECT_EQ(stringResults.size(), 4);  // 4 from task2
+
+    // Check specific values from task1
+    bool foundInt10 = false, foundInt15 = false;
+    bool foundDouble7_5 = false, foundDouble12_5 = false;
+
+    for (const auto& res : intResults) {
+        if (res->value == 10) foundInt10 = true;
+        if (res->value == 15) foundInt15 = true;
+    }
+
+    for (const auto& res : doubleResults) {
+        if (res->value == 7.5) foundDouble7_5 = true;
+        if (res->value == 12.5) foundDouble12_5 = true;
+    }
+
+    EXPECT_TRUE(foundInt10);
+    EXPECT_TRUE(foundInt15);
+    EXPECT_TRUE(foundDouble7_5);
+    EXPECT_TRUE(foundDouble12_5);
+}
+
+TEST(BatchAddResult, basicTest) {
+    ASSERT_NO_THROW(batchAddResultBasicTest());
+}
+
+TEST(BatchAddResult, complexTest) {
+    ASSERT_NO_THROW(batchAddResultComplexTest());
+}


### PR DESCRIPTION
The goal is to limit the amount of time senders and receivers have to lock the queue. The batch operations are especially useful when using states / sequential tasks.

## Summary
- New task API functions:
  - `batchAddResult`: add a vector of result; locks the receiver queue only once.
  - `bufferResult`, `flushResults`: similar to `batchAddResult`, but uses the tasks internal buffer (can be useful in some situations).
- **Sender changes**: the senders are now able to retrieve multiple inputs from the input queue (one lock). The number of dequeued elements is computed using the number of threads of the tasks and the size of the queue after the last receive (not the current queue size; this part could be improved).
- **Receiver changes**: the receivers now have a `batchReceive` and a `getInputDatas` operations. Receivers are also expected to register and save the queue size after receiving (this size should be updated only on reception).
- **State manager**: the slow `emptyReadyList` operation on state managers now use the `batchSend` function from the sender to avoid locking the queue multiple times.